### PR TITLE
[Refactoring]  new judger agent  

### DIFF
--- a/examples/scripts/run_judger_standalone.py
+++ b/examples/scripts/run_judger_standalone.py
@@ -300,24 +300,6 @@ def main():
         if args.print_result:
             _print_result(result)
 
-        # 最终结果输出到 stdout（Codex 消费）
-        judger = result.get("judger", {})
-        payload = {
-            "ok": True,
-            "status": "completed",
-            "message": "Judger pipeline completed.",
-            "data": {
-                "task_type": judger.get("eval_task_type"),
-                "output_result_path": judger.get("output_result_path"),
-                "output_case_path": judger.get("output_case_path"),
-                "output_problem_path": judger.get("output_problem_path"),
-                "output_pred_path": judger.get("output_pred_path"),
-                "bench": judger.get("bench"),
-            },
-            "error": None,
-        }
-        print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
-
         if args.print_events:
             task_id = result.get("task_id") or thread_id
             output_dir = result.get("output_dir") or args.output_dir or "./outputs"
@@ -331,24 +313,36 @@ def main():
                     file=sys.stderr,
                 )
 
-    except Exception as exc:
-        import traceback
+        # 最终结果用标准 payload 输出到 stdout（Codex 消费）
+        from loopai.common.exception import emit_success
 
-        payload = {
-            "ok": False,
-            "status": "failed",
-            "message": "Judger pipeline failed.",
-            "data": None,
-            "error": {
-                "type": type(exc).__name__,
-                "code": "JUDGER_ERROR",
-                "detail": str(exc),
-                "traceback": traceback.format_exc(),
-                "recoverable": True,
+        judger = result.get("judger", {})
+        emit_success(
+            data={
+                "task_type": judger.get("eval_task_type"),
+                "output_result_path": judger.get("output_result_path"),
+                "output_case_path": judger.get("output_case_path"),
+                "output_problem_path": judger.get("output_problem_path"),
+                "output_pred_path": judger.get("output_pred_path"),
+                "bench": judger.get("bench"),
             },
-        }
-        print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
-        sys.exit(1)
+            message="Judger pipeline completed.",
+        )
+
+    except Exception as exc:
+        from loopai.common.exception import emit_error, ErrorCode
+
+        # 根据异常类型分派 ErrorCode
+        if isinstance(exc, ValueError):
+            code = ErrorCode.CONFIG_ERROR
+        elif isinstance(exc, FileNotFoundError):
+            code = ErrorCode.NOT_FOUND
+        elif isinstance(exc, RuntimeError):
+            code = ErrorCode.EXTERNAL_SERVICE_ERROR
+        else:
+            code = ErrorCode.UNHANDLED_EXCEPTION
+
+        emit_error(exc, code=code, recoverable=True, message="Judger pipeline failed.")
 
 
 if __name__ == "__main__":

--- a/examples/scripts/run_judger_standalone.py
+++ b/examples/scripts/run_judger_standalone.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Standalone Judger CLI entry point.
+
+Usage:
+    # 直接用 starter.yaml（推荐）
+    python examples/scripts/run_judger_standalone.py \
+        --config-path examples/config/starter.yaml \
+        --print-result
+
+    # 也可以用 JSON 配置文件
+    python examples/scripts/run_judger_standalone.py \
+        --config-path /tmp/judger_config.json \
+        --print-result
+
+    # 断点续跑
+    python examples/scripts/run_judger_standalone.py \
+        --config-path examples/config/starter.yaml \
+        --resume
+
+    python examples/scripts/run_judger_standalone.py --list-steps
+
+配置文件支持两种格式：
+1. starter.yaml — 自动从 default_states.judger 提取 judger 配置
+2. JSON — {"judger": {...}, "task_id": "...", "output_dir": "..."}
+
+环境变量可覆盖配置文件中的值：
+    JUDGER_MODEL_PATH, JUDGER_TASK_TYPE, JUDGER_TEMPERATURE,
+    JUDGER_TOP_P, JUDGER_PROBLEM_PATH, JUDGER_BATCH_SIZE,
+    JUDGER_CASE_NUM, TASK_ID, OUTPUT_DIR, CUDA_VISIBLE_DEVICES,
+    JUDGER_CHECKPOINT_PATH
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def _load_yaml(path: str) -> Dict[str, Any]:
+    """加载 YAML 文件（优先 yaml 库，回退到简单解析）。"""
+    try:
+        import yaml
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except ImportError:
+        pass
+    # 回退：简单 YAML 解析（支持 starter.yaml 的两层嵌套结构）
+    return _parse_simple_yaml(path)
+
+
+def _parse_simple_yaml(path: str) -> Dict[str, Any]:
+    """极简 YAML 解析器，只处理 starter.yaml 这种两层缩进结构。"""
+    import re
+    result: Dict[str, Any] = {}
+    stack: list = [(result, -1)]
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            stripped = line.rstrip()
+            if not stripped or stripped.lstrip().startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            # 匹配 key: value
+            m = re.match(r"^(\s*)([\w_-]+):\s*(.*)", stripped)
+            if not m:
+                continue
+            key = m.group(2)
+            value = m.group(3).strip()
+            indent = len(m.group(1))
+            # 弹出比当前缩进深的层级
+            while stack and stack[-1][1] >= indent:
+                stack.pop()
+            parent = stack[-1][0]
+            if value in ("", "{}", "[]"):
+                # 嵌套对象或空值
+                child: Dict[str, Any] = {}
+                parent[key] = child
+                stack.append((child, indent))
+            elif value.startswith('"') and value.endswith('"'):
+                parent[key] = value[1:-1]
+            elif value.startswith("'") and value.endswith("'"):
+                parent[key] = value[1:-1]
+            else:
+                # 尝试类型推断
+                parent[key] = _coerce_yaml_value(value)
+    return result
+
+
+def _coerce_yaml_value(value: str) -> Any:
+    v = value.strip()
+    if v.lower() == "true":
+        return True
+    if v.lower() == "false":
+        return False
+    if v.lower() in ("null", "~"):
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+
+def _load_config(config_path: str) -> Dict[str, Any]:
+    """加载配置文件，自动识别 YAML/JSON。"""
+    ext = Path(config_path).suffix.lower()
+    if ext in (".yaml", ".yml"):
+        return _load_yaml(config_path)
+    elif ext == ".json":
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    else:
+        # 尝试 YAML 优先
+        try:
+            return _load_yaml(config_path)
+        except Exception:
+            with open(config_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+
+def _extract_state_from_starter_yaml(config: Dict[str, Any]) -> Dict[str, Any]:
+    """从 starter.yaml 格式提取 state 字典。
+
+    starter.yaml 结构：
+        default_states:
+          task_id: "..."
+          output_dir: "..."
+          judger:
+            eval_model_path: "..."
+            ...
+        system:
+          CUDA_VISIBLE_DEVICES: "..."
+    """
+    defaults = config.get("default_states", {})
+    system = config.get("system", {})
+
+    judger = dict(defaults.get("judger", {}))
+
+    # 从 system 补充 GPU 配置
+    if "cuda_visible_devices" not in judger and "CUDA_VISIBLE_DEVICES" in system:
+        judger["cuda_visible_devices"] = str(system["CUDA_VISIBLE_DEVICES"])
+
+    return {
+        "judger": judger,
+        "task_id": defaults.get("task_id", ""),
+        "output_dir": defaults.get("output_dir", "./outputs"),
+    }
+
+
+def _print_result(state: Dict[str, Any]):
+    judger = state.get("judger", {})
+    print("\n=== Judger Pipeline Complete ===")
+    print(f"Task Type:     {judger.get('eval_task_type', 'N/A')}")
+    print(f"Task ID:       {state.get('task_id', 'N/A')}")
+    print(f"Result Path:   {judger.get('output_result_path', 'N/A')}")
+    print(f"Sample Path:   {judger.get('output_case_path', 'N/A')}")
+    print(f"Problem Path:  {judger.get('output_problem_path', 'N/A')}")
+    pred_path = judger.get("output_pred_path", "")
+    if pred_path:
+        print(f"Pred Path:     {pred_path}")
+    bench = judger.get("bench")
+    if bench and isinstance(bench, dict):
+        print(f"Bench Name:    {bench.get('bench_name', 'N/A')}")
+        print(f"Eval Status:   {bench.get('eval_status', 'N/A')}")
+        meta = bench.get("meta") or {}
+        stats = meta.get("eval_result") or {}
+        if stats:
+            print("Stats:")
+            for k, v in stats.items():
+                print(f"  {k}: {v}")
+
+
+def _list_steps():
+    from loopai.skills.Judger.runner import JUDGER_PIPELINE_STEPS
+
+    print("Available Judger pipeline steps:")
+    for step in JUDGER_PIPELINE_STEPS:
+        print(f"  - {step}")
+    print()
+    print("code/text2sql pipeline:")
+    print("  validate -> kill_vllm -> start_vllm -> format_data -> generate -> evaluate -> kill_vllm_cleanup -> finish")
+    print()
+    print("general_text pipeline:")
+    print("  validate -> eval_general_text -> finish")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run LoopAI Judger standalone (no LangGraph required)",
+    )
+    parser.add_argument(
+        "--config-path",
+        type=str,
+        default=None,
+        help="Config file: starter.yaml or JSON",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        default=False,
+        help="Resume from last checkpoint",
+    )
+    parser.add_argument(
+        "--from-step",
+        type=str,
+        default=None,
+        help="Force start from a specific pipeline step",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        type=str,
+        default=None,
+        help="SQLite checkpoint file path",
+    )
+    parser.add_argument(
+        "--task-id",
+        type=str,
+        default=None,
+        help="Override task id",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Override output directory",
+    )
+    parser.add_argument(
+        "--print-result",
+        action="store_true",
+        default=False,
+        help="Print result paths to stderr",
+    )
+    parser.add_argument(
+        "--print-events",
+        action="store_true",
+        default=False,
+        help="Print event list from judger.pkl after execution",
+    )
+    parser.add_argument(
+        "--list-steps",
+        action="store_true",
+        default=False,
+        help="Print available pipeline steps and exit",
+    )
+
+    args = parser.parse_args()
+
+    if args.list_steps:
+        _list_steps()
+        return
+
+    from loopai.skills.Judger import run
+
+    kwargs: Dict[str, Any] = {}
+    if args.task_id:
+        kwargs["task_id"] = args.task_id
+    if args.output_dir:
+        kwargs["output_dir"] = args.output_dir
+
+    # 从配置文件构建 state
+    state: Optional[Dict[str, Any]] = None
+    task_id_from_config: Optional[str] = None
+    if args.config_path:
+        config = _load_config(args.config_path)
+        if "default_states" in config:
+            # starter.yaml 格式
+            state = _extract_state_from_starter_yaml(config)
+        else:
+            # 纯 JSON 格式：{"judger": {...}, "task_id": "..."}
+            state = {
+                "judger": config.get("judger", {}),
+                "task_id": args.task_id or config.get("task_id", ""),
+                "output_dir": args.output_dir or config.get("output_dir", "./outputs"),
+            }
+            for key in ("trainer", "analyzer", "obtainer", "constructor"):
+                if key in config:
+                    state[key] = config[key]
+        task_id_from_config = state.get("task_id")
+
+    thread_id = args.task_id or task_id_from_config or os.getenv("TASK_ID") or "judger-default"
+
+    try:
+        result = run(
+            state=state,
+            thread_id=thread_id,
+            resume=args.resume,
+            from_step=args.from_step,
+            checkpoint_path=args.checkpoint_path,
+            **kwargs,
+        )
+
+        if args.print_result:
+            _print_result(result)
+
+        # 最终结果输出到 stdout（Codex 消费）
+        judger = result.get("judger", {})
+        payload = {
+            "ok": True,
+            "status": "completed",
+            "message": "Judger pipeline completed.",
+            "data": {
+                "task_type": judger.get("eval_task_type"),
+                "output_result_path": judger.get("output_result_path"),
+                "output_case_path": judger.get("output_case_path"),
+                "output_problem_path": judger.get("output_problem_path"),
+                "output_pred_path": judger.get("output_pred_path"),
+                "bench": judger.get("bench"),
+            },
+            "error": None,
+        }
+        print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
+
+        if args.print_events:
+            task_id = result.get("task_id") or thread_id
+            output_dir = result.get("output_dir") or args.output_dir or "./outputs"
+            from loopai.skills.Judger import load_events
+            events = load_events(task_id=task_id, output_dir=output_dir)
+            print(f"\n=== Events ({len(events)}) ===", file=sys.stderr)
+            for evt in events:
+                print(
+                    f"  [{evt.get('time', '?')}] "
+                    f"progress={evt.get('progress')} {evt.get('message', '')}",
+                    file=sys.stderr,
+                )
+
+    except Exception as exc:
+        import traceback
+
+        payload = {
+            "ok": False,
+            "status": "failed",
+            "message": "Judger pipeline failed.",
+            "data": None,
+            "error": {
+                "type": type(exc).__name__,
+                "code": "JUDGER_ERROR",
+                "detail": str(exc),
+                "traceback": traceback.format_exc(),
+                "recoverable": True,
+            },
+        }
+        print(json.dumps(payload, ensure_ascii=False, default=str), flush=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    from multiprocessing import freeze_support
+    freeze_support()
+    main()

--- a/loopai/agents/Judger/__init__.py
+++ b/loopai/agents/Judger/__init__.py
@@ -1,1 +1,14 @@
-from .judger_agent import JudgerAgent
+"""Lightweight Judger exports.
+
+Keep this module cheap to import so Codex/CLI can import Judger submodules
+without loading JudgerAgent, LangGraph, or vLLM dependencies.
+"""
+
+__all__ = ["JudgerAgent"]
+
+
+def __getattr__(name):
+    if name == "JudgerAgent":
+        from .judger_agent import JudgerAgent
+        return JudgerAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/loopai/skills/Judger/__init__.py
+++ b/loopai/skills/Judger/__init__.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def run(
+    state: Optional[Dict[str, Any]] = None,
+    thread_id: Optional[str] = None,
+    resume: bool = False,
+    from_step: Optional[str] = None,
+    checkpoint_path: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Run Judger standalone (Codex / CLI entry point).
+
+    事件会在流水线执行期间实时写入
+    ``<output_dir>/<task_id>/judger.pkl``。
+
+    Args:
+        state: Full state dict with ``state["judger"]`` config fields.
+            Required unless ``resume=True``.
+        thread_id: Checkpoint thread id (default: ``"judger-default"``).
+        resume: If True, load state from checkpoint and resume.
+        from_step: Force start from a specific pipeline step name.
+        checkpoint_path: Path to sqlite checkpoint file.
+        **kwargs: Runtime overrides.
+
+    Returns:
+        Final state dict.
+    """
+    from loopai.skills.Judger.runner import run_judger_pipeline
+
+    return run_judger_pipeline(
+        state=state,
+        thread_id=thread_id,
+        checkpoint_path=checkpoint_path,
+        resume=resume,
+        from_step=from_step,
+        **kwargs,
+    )
+
+
+def load_events(
+    task_id: str,
+    output_dir: str = "./outputs",
+) -> List[Dict[str, Any]]:
+    """读取指定任务的 judger 事件列表。
+
+    事件在流水线执行期间实时写入 pickle 文件（``judger.pkl``），
+    执行完成后可调用此函数获取完整事件列表，用于前端展示或日志分析。
+
+    Args:
+        task_id: 任务 ID（对应 run() 的 thread_id）。
+        output_dir: 输出根目录，默认 ``"./outputs"``。
+
+    Returns:
+        StreamEvent dict 列表，按写入时间排序。
+    """
+    from loopai.common.event_tool import dump_stream_events_json
+
+    return dump_stream_events_json(
+        name="judger",
+        context_id=task_id,
+        log_file_path=output_dir,
+    )
+
+
+__all__ = ["run", "load_events"]

--- a/loopai/skills/Judger/runner.py
+++ b/loopai/skills/Judger/runner.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from loopai.common.event_tool import StreamEvent, get_event_writer
+from loopai.common.exception import emit_error, ErrorCode
 from loopai.logger import get_logger
 
 logger = get_logger()
+
 
 # ---------------------------------------------------------------------------
 # Judger pipeline constants / 流水线步骤常量
@@ -164,7 +166,11 @@ def _start_index(step_name: str, steps: tuple) -> int:
     norm = normalize_judger_step(step_name)
     if norm not in steps:
         available = ", ".join(steps)
-        raise ValueError(f"Unknown Judger step: {step_name}. Available: {available}")
+        emit_error(
+            ValueError(f"Unknown Judger step: {step_name}. Available: {available}"),
+            code=ErrorCode.INVALID_INPUT, recoverable=True,
+            message=f"Step '{step_name}' is not valid for the current pipeline.",
+        )
     return steps.index(norm)
 
 
@@ -215,7 +221,7 @@ def _step_validate(state: Dict[str, Any], writer) -> Dict[str, Any]:
     from loopai.schema.states import get_missing_fields
 
     judger = state.get("judger", {})
-    task_type = judger.get("eval_task_type", "code")
+    task_type = judger.get("eval_task_type","")
 
     writer(StreamEvent(
         current="judger", progress=0.0, message="开始校验配置参数"))
@@ -260,9 +266,11 @@ def _step_validate(state: Dict[str, Any], writer) -> Dict[str, Any]:
         missing.setdefault("judger", []).append("eval_problem_path")
 
     if missing:
-        raise ValueError(
-            f"Missing required fields: "
-            f"{json.dumps({'missing_fields': missing}, ensure_ascii=False)}"
+        emit_error(
+            ValueError(f"Missing required fields: "
+                       f"{json.dumps({'missing_fields': missing}, ensure_ascii=False)}"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message="Judger configuration is incomplete.",
         )
 
     # 5. JSONL 字段校验
@@ -277,13 +285,21 @@ def _step_validate(state: Dict[str, Any], writer) -> Dict[str, Any]:
             required = ["task_id", "prompt", "entry_point", "canonical_solution", "test_list"]
         ok, details = check_jsonl_fields(problem_path, required)
         if not ok:
-            raise ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}")
+            emit_error(
+                ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}"),
+                code=ErrorCode.INVALID_INPUT, recoverable=True,
+                message=f"Problem file {problem_path} has invalid fields for task type {task_type}.",
+            )
     elif task_type == "text2sql":
         from loopai.agents.Judger.utils.oj.data import check_jsonl_fields
         required = ["task_id", "prompt", "db_id", "question", "ground_truth"]
         ok, details = check_jsonl_fields(problem_path, required)
         if not ok:
-            raise ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}")
+            emit_error(
+                ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}"),
+                code=ErrorCode.INVALID_INPUT, recoverable=True,
+                message=f"Problem file {problem_path} has invalid fields for task type {task_type}.",
+            )
 
     # 6. 重置输出路径
     state["judger"]["output_result_path"] = ""
@@ -323,7 +339,11 @@ def _step_start_vllm(state: Dict[str, Any], writer) -> Dict[str, Any]:
     model_path = judger.get("eval_model_path")
 
     if not model_path:
-        raise ValueError("eval_model_path is required for local vLLM startup")
+        emit_error(
+            ValueError("eval_model_path is required for local vLLM startup"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message="Missing eval_model_path for vLLM startup.",
+        )
 
     cuda_devices = judger.get("cuda_visible_devices", "0")
     env_configs = json.dumps({
@@ -345,26 +365,18 @@ def _step_start_vllm(state: Dict[str, Any], writer) -> Dict[str, Any]:
 
 def _step_format_data(state: Dict[str, Any], writer) -> Dict[str, Any]:
     """可选的数据格式转换步骤（human-eval、mbpp 等）。"""
-    from loopai.agents.Judger.utils.oj.format import data_format
-
     judger = state.get("judger", {})
     format_type = judger.get("eval_format_type")
 
     if format_type and format_type != "":
-        problem_path = judger.get("eval_problem_path", "")
-        task_id = state.get("task_id")
-        output_dir = Path(state.get("output_dir", "."))
-        file_stem = Path(problem_path).stem
-        target = output_dir / str(task_id) / "judger" / f"{file_stem}_format.jsonl"
-
+        from loopai.skills.Judger.utils.format import run_format_data
         writer(StreamEvent(
             current="judger", progress=0.0,
             message=f"正在进行数据格式转换 [{format_type}]"))
-        data_format(state)
-        state["judger"]["eval_problem_path"] = str(target)
+        run_format_data(state, writer)
         writer(StreamEvent(
             current="judger", progress=1.0, message="数据格式转换完成",
-            data={"target": str(target)}))
+            data={"target": state["judger"]["eval_problem_path"]}))
     else:
         writer(StreamEvent(
             current="judger", progress=1.0,
@@ -376,6 +388,8 @@ def _step_format_data(state: Dict[str, Any], writer) -> Dict[str, Any]:
 
 def _step_generate(state: Dict[str, Any], writer) -> Dict[str, Any]:
     """样本生成步骤：调用 vLLM 批量生成 code/text2sql 样本。"""
+    from loopai.skills.Judger.utils.generate import run_generate_code, run_generate_text2sql
+
     task_type = state.get("judger", {}).get("eval_task_type", "code")
     batch_size = state.get("judger", {}).get("eval_batch_size", 10)
     case_num = state.get("judger", {}).get("eval_case_num", 10)
@@ -386,13 +400,15 @@ def _step_generate(state: Dict[str, Any], writer) -> Dict[str, Any]:
         data={"batch_size": batch_size, "case_num": case_num}))
 
     if task_type == "code":
-        from loopai.agents.Judger.utils.oj.generate import generate_sample_code
-        result_path = generate_sample_code(state)
+        result_path = run_generate_code(state, writer)
     elif task_type == "text2sql":
-        from loopai.agents.Judger.utils.oj.generate import generate_sample_text2sql
-        result_path = generate_sample_text2sql(state)
+        result_path = run_generate_text2sql(state, writer)
     else:
-        raise ValueError(f"Unsupported task type for generate step: {task_type}")
+        emit_error(
+            ValueError(f"Unsupported task type for generate step: {task_type}"),
+            code=ErrorCode.INVALID_INPUT, recoverable=True,
+            message=f"Task type '{task_type}' is not supported for sample generation.",
+        )
 
     state["judger"]["output_case_path"] = result_path
     writer(StreamEvent(
@@ -403,6 +419,8 @@ def _step_generate(state: Dict[str, Any], writer) -> Dict[str, Any]:
 
 def _step_evaluate(state: Dict[str, Any], writer) -> Dict[str, Any]:
     """样本评测步骤：执行代码/执行 SQL，计算 pass@k。"""
+    from loopai.skills.Judger.utils.evaluate import run_evaluate_code, run_evaluate_text2sql
+
     task_type = state.get("judger", {}).get("eval_task_type", "code")
 
     writer(StreamEvent(
@@ -410,13 +428,15 @@ def _step_evaluate(state: Dict[str, Any], writer) -> Dict[str, Any]:
         message=f"开始评测样本 [task_type={task_type}]"))
 
     if task_type == "code":
-        from loopai.agents.Judger.utils.oj.evaluate import evaluate_sample_code
-        result = evaluate_sample_code(state)
+        result = run_evaluate_code(state, writer)
     elif task_type == "text2sql":
-        from loopai.agents.Judger.utils.oj.evaluate import evaluate_sample_text2sql
-        result = evaluate_sample_text2sql(state)
+        result = run_evaluate_text2sql(state, writer)
     else:
-        raise ValueError(f"Unsupported task type for evaluate step: {task_type}")
+        emit_error(
+            ValueError(f"Unsupported task type for evaluate step: {task_type}"),
+            code=ErrorCode.INVALID_INPUT, recoverable=True,
+            message=f"Task type '{task_type}' is not supported for evaluation.",
+        )
 
     state["judger"]["output_result_path"] = result.get("result_path", "")
     writer(StreamEvent(
@@ -452,7 +472,11 @@ def _run_step(step_name: str, state: Dict[str, Any], writer) -> Dict[str, Any]:
         return dispatch[step](state, writer)
     if step == "finish":
         return state
-    raise ValueError(f"Unknown executable Judger step: {step_name}")
+    emit_error(
+        ValueError(f"Unknown executable Judger step: {step_name}"),
+        code=ErrorCode.INVALID_INPUT, recoverable=True,
+        message=f"Step '{step_name}' is not a recognized Judger pipeline step.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +521,11 @@ def run_judger_pipeline(
         state = load_judger_checkpoint(thread_id, checkpoint_path)
         resolve_judger_runtime_config(state, thread_id=thread_id, **kwargs)
     elif state is None:
-        raise ValueError("state is required when resume is False.")
+        emit_error(
+            ValueError("state is required when resume is False."),
+            code=ErrorCode.INVALID_INPUT, recoverable=True,
+            message="No state provided and resume is disabled.",
+        )
     else:
         state = dict(state) if state is not None else {}
         state.setdefault("judger", {})

--- a/loopai/skills/Judger/runner.py
+++ b/loopai/skills/Judger/runner.py
@@ -1,0 +1,576 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from loopai.common.event_tool import StreamEvent, get_event_writer
+from loopai.logger import get_logger
+
+logger = get_logger()
+
+# ---------------------------------------------------------------------------
+# Judger pipeline constants / 流水线步骤常量
+# ---------------------------------------------------------------------------
+
+# 完整流水线步骤列表（供 CLI --list-steps 使用）
+JUDGER_PIPELINE_STEPS = (
+    "validate",            # 校验必填字段和文件有效性
+    "kill_vllm",           # 关闭本地 vLLM 进程
+    "start_vllm",          # 启动本地 vLLM 服务
+    "format_data",         # 可选的数据格式转换
+    "generate",            # 生成 code/text2sql 样本
+    "evaluate",            # 评测样本并计算 pass@k
+    "kill_vllm_cleanup",   # 评测完成后关闭 vLLM
+    "eval_general_text",   # 通用文本评测（One-Eval DataFlow）
+    "finish",              # 流水线结束
+)
+
+# 步骤别名：将 LangGraph 节点名称 / 旧名称映射到标准步骤名
+# 用于 CLI --from-step 参数兼容和 checkpoint 恢复
+_STEP_ALIASES = {
+    "check_required_fields": "validate",
+    "check_param_type": "validate",
+    "vllm_kill": "kill_vllm",
+    "vllm_start": "start_vllm",
+    "data_format": "format_data",
+    "generate_code": "generate",
+    "evaluate_node": "evaluate",
+    "eval_general_text_node": "eval_general_text",
+    "vllm_kill_node": "kill_vllm_cleanup",
+    "finish_node": "finish",
+}
+
+# code / text2sql 任务的流水线步骤
+_CODE_TEXTSQL_STEPS = (
+    "validate",
+    "kill_vllm",
+    "start_vllm",
+    "format_data",
+    "generate",
+    "evaluate",
+    "kill_vllm_cleanup",
+    "finish",
+)
+
+# general_text 任务的流水线步骤（不需要 vLLM 生命周期管理）
+_GENERAL_TEXT_STEPS = (
+    "validate",
+    "eval_general_text",
+    "finish",
+)
+
+# Checkpoint 表的建表 DDL（SQLite）
+_CHECKPOINT_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS judger_checkpoints (
+    thread_id TEXT PRIMARY KEY,
+    state_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint helpers
+# ---------------------------------------------------------------------------
+
+def _json_safe(value: Any) -> Any:
+    """递归转换值为 JSON 可序列化形式。"""
+    try:
+        json.dumps(value, ensure_ascii=False)
+        return value
+    except TypeError:
+        if isinstance(value, dict):
+            return {str(key): _json_safe(child) for key, child in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_json_safe(item) for item in value]
+        return str(value)
+
+
+def normalize_judger_step(step_name: Optional[str]) -> Optional[str]:
+    """将步骤名标准化为流水线中定义的标准名称。
+
+    支持：标准名称、别名、包含别名的字符串、模糊匹配。
+    """
+    if not step_name:
+        return None
+    step_name = str(step_name)
+    if step_name in JUDGER_PIPELINE_STEPS:
+        return step_name
+    if step_name in _STEP_ALIASES:
+        return _STEP_ALIASES[step_name]
+    for alias, step in _STEP_ALIASES.items():
+        if alias in step_name:
+            return step
+    for step in JUDGER_PIPELINE_STEPS:
+        if step in step_name:
+            return step
+    return step_name
+
+
+def _connect(checkpoint_path: str):
+    """创建到 SQLite checkpoint 数据库的连接，并自动建表。"""
+    import sqlite3
+
+    d = os.path.dirname(checkpoint_path)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    conn = sqlite3.connect(checkpoint_path)
+    conn.execute(_CHECKPOINT_TABLE_DDL)
+    conn.commit()
+    return conn
+
+
+def save_judger_checkpoint(
+    state: Dict[str, Any], thread_id: str, checkpoint_path: str
+) -> None:
+    """将当前 state 保存到 checkpoint（SQLite UPSERT）。"""
+    payload = json.dumps(_json_safe(state), ensure_ascii=False)
+    updated_at = datetime.now(timezone.utc).isoformat()
+    with _connect(checkpoint_path) as conn:
+        conn.execute(
+            """INSERT INTO judger_checkpoints(thread_id, state_json, updated_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(thread_id) DO UPDATE SET
+                   state_json = excluded.state_json,
+                   updated_at = excluded.updated_at""",
+            (thread_id, payload, updated_at),
+        )
+        conn.commit()
+
+
+def load_judger_checkpoint(thread_id: str, checkpoint_path: str) -> Dict[str, Any]:
+    """从 checkpoint 加载之前保存的 state。"""
+    if not os.path.exists(checkpoint_path):
+        raise RuntimeError(
+            f"No checkpoint found for thread_id={thread_id} in {checkpoint_path}"
+        )
+    with _connect(checkpoint_path) as conn:
+        row = conn.execute(
+            "SELECT state_json FROM judger_checkpoints WHERE thread_id = ? LIMIT 1",
+            (thread_id,),
+        ).fetchone()
+    if row is None:
+        raise RuntimeError(
+            f"No checkpoint found for thread_id={thread_id} in {checkpoint_path}"
+        )
+    return json.loads(row[0])
+
+
+def _start_index(step_name: str, steps: tuple) -> int:
+    """获取指定步骤在流水线步骤元组中的索引位置。"""
+    norm = normalize_judger_step(step_name)
+    if norm not in steps:
+        available = ", ".join(steps)
+        raise ValueError(f"Unknown Judger step: {step_name}. Available: {available}")
+    return steps.index(norm)
+
+
+def _resume_step_from_state(state: Dict[str, Any]) -> str:
+    """根据 state 中的 last_completed 推断应从哪个步骤恢复。
+
+    last_completed 是上次已完成步骤名，从它的下一个步骤继续。
+    如果 last_completed 不存在或为 "finish"，从头开始。
+    """
+    last_completed = normalize_judger_step(state.get("last_completed"))
+
+    task_type = (state.get("judger") or {}).get("eval_task_type", "code")
+    steps = _GENERAL_TEXT_STEPS if task_type == "general_text" else _CODE_TEXTSQL_STEPS
+
+    if last_completed and last_completed in steps and last_completed != "finish":
+        next_index = min(_start_index(last_completed, steps) + 1, len(steps) - 1)
+        return steps[next_index]
+    return steps[0]
+
+
+def _is_finished(state: Dict[str, Any]) -> bool:
+    """检查流水线是否已经完成（last_completed == "finish"）。"""
+    return normalize_judger_step(state.get("last_completed")) == "finish"
+
+
+# ---------------------------------------------------------------------------
+# Per-step implementations / 各步骤实现
+# ---------------------------------------------------------------------------
+
+def _find_best_checkpoint(
+    checkpoints: List[str],
+    training_step_losses: List[Dict[str, Any]],
+) -> str:
+    """根据训练 loss 选择最佳 checkpoint 目录。"""
+    best_step = min(training_step_losses, key=lambda x: (x["loss"], x["step"]))["step"]
+
+    def _extract_num(cp: str) -> int:
+        return int(cp.split("-")[-1])
+
+    return min(
+        checkpoints,
+        key=lambda cp: (abs(_extract_num(cp) - best_step), _extract_num(cp)),
+    )
+
+
+def _step_validate(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """验证步骤：检查必填字段、文件存在性和 JSONL 字段结构。"""
+    from loopai.schema.states import get_missing_fields
+
+    judger = state.get("judger", {})
+    task_type = judger.get("eval_task_type", "code")
+
+    writer(StreamEvent(
+        current="judger", progress=0.0, message="开始校验配置参数"))
+
+    # 1. 检查通用必填字段
+    required_fields = {
+        "judger": [
+            "eval_temperature", "eval_top_p", "eval_problem_path",
+            "eval_case_num", "eval_task_type",
+        ],
+        "default": ["output_dir", "task_id"],
+    }
+    missing = get_missing_fields(required_fields, state)
+
+    # 2. 模型路径：未配置时尝试从 trainer 的 checkpoint 推断
+    if not missing:
+        model_path = judger.get("eval_model_path", "")
+        if not model_path or model_path == "":
+            trainer = state.get("trainer", {})
+            trainer_task_id = trainer.get("trainer_task_id", "")
+            training_checkpoints = trainer.get("training_checkpoints", "")
+            training_step_losses = trainer.get("training_step_losses", "")
+            output_dir = state.get("output_dir", "")
+            if trainer_task_id and training_checkpoints and training_step_losses:
+                best = _find_best_checkpoint(training_checkpoints, training_step_losses)
+                state["judger"]["eval_model_path"] = (
+                    f"{output_dir}/{state.get('task_id')}/trainer/"
+                    f"{trainer_task_id}/{best}/"
+                )
+            else:
+                missing.setdefault("judger", []).append("eval_model_path")
+
+    # 3. 特定任务类型额外字段
+    if not missing and task_type == "text2sql":
+        missing = get_missing_fields({"judger": ["eval_text2sql_dir"]}, state)
+    if not missing and task_type == "general_text":
+        missing = get_missing_fields({"judger": ["bench_dataflow_eval_type"]}, state)
+
+    # 4. 问题文件存在性
+    problem_path = judger.get("eval_problem_path", "")
+    if not problem_path or not os.path.exists(problem_path):
+        missing.setdefault("judger", []).append("eval_problem_path")
+
+    if missing:
+        raise ValueError(
+            f"Missing required fields: "
+            f"{json.dumps({'missing_fields': missing}, ensure_ascii=False)}"
+        )
+
+    # 5. JSONL 字段校验
+    if task_type == "code":
+        from loopai.agents.Judger.utils.oj.data import check_jsonl_fields
+        fmt = judger.get("eval_format_type", "")
+        if fmt == "mbpp":
+            required = ["text", "code", "task_id", "challenge_test_list", "test_list"]
+        elif fmt == "human-eval":
+            required = ["task_id", "prompt", "entry_point", "canonical_solution", "test"]
+        else:
+            required = ["task_id", "prompt", "entry_point", "canonical_solution", "test_list"]
+        ok, details = check_jsonl_fields(problem_path, required)
+        if not ok:
+            raise ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}")
+    elif task_type == "text2sql":
+        from loopai.agents.Judger.utils.oj.data import check_jsonl_fields
+        required = ["task_id", "prompt", "db_id", "question", "ground_truth"]
+        ok, details = check_jsonl_fields(problem_path, required)
+        if not ok:
+            raise ValueError(f"JSONL field validation failed: {json.dumps(details, ensure_ascii=False, indent=2)}")
+
+    # 6. 重置输出路径
+    state["judger"]["output_result_path"] = ""
+    state["judger"]["output_case_path"] = ""
+    state["judger"]["output_problem_path"] = ""
+
+    writer(StreamEvent(
+        current="judger", progress=1.0, message="配置校验通过",
+        data={"task_type": task_type, "problem_path": problem_path}))
+    return state
+
+
+def _step_kill_vllm(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """关闭本地 vLLM 进程（端口 8911）。"""
+    from loopai.agents.Judger.utils.oj.vllm_killer import kill_vllm_openai_api_server
+    from loopai.agents.Judger.utils.oj.vllm_starter import DEFAULT_VLLM_PORT
+
+    writer(StreamEvent(current="judger", progress=0.0, message="正在关闭本地 vLLM 服务"))
+    kill_vllm_openai_api_server(DEFAULT_VLLM_PORT)
+    state["judger"]["eval_base_url"] = None
+    writer(StreamEvent(current="judger", progress=1.0, message="vLLM 服务已关闭"))
+    return state
+
+
+def _step_start_vllm(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """启动本地 vLLM 服务。"""
+    from loopai.agents.Judger.utils.oj.vllm_starter import (
+        start_vllm_openai_api_server, DEFAULT_VLLM_PORT,
+    )
+    from loopai.agents.Judger.nodes.eval_general_text_node import set_gpu
+
+    judger = state.get("judger", {})
+    set_gpu(state)
+
+    tensor_parallel_size = judger.get("eval_vllm_tensor_parallel_size", 1)
+    gpu_memory_utilization = judger.get("eval_vllm_gpu_memory_utilization", 0.9)
+    model_path = judger.get("eval_model_path")
+
+    if not model_path:
+        raise ValueError("eval_model_path is required for local vLLM startup")
+
+    cuda_devices = judger.get("cuda_visible_devices", "0")
+    env_configs = json.dumps({
+        "CUDA_VISIBLE_DEVICES": str(cuda_devices),
+        "NCCL_P2P_DISABLE": "1", "NCCL_IB_DISABLE": "1",
+        "NCCL_DEBUG": "INFO", "NCCL_SOCKET_IFNAME": "lo", "NCCL_BLOCKING_WAIT": "1",
+    })
+
+    writer(StreamEvent(
+        current="judger", progress=0.0, message="正在启动本地 vLLM 服务",
+        data={"model_path": model_path, "tensor_parallel_size": tensor_parallel_size}))
+    start_vllm_openai_api_server(env_configs, tensor_parallel_size, gpu_memory_utilization, model_path)
+    state["judger"]["eval_base_url"] = f"http://localhost:{DEFAULT_VLLM_PORT}/v1"
+    writer(StreamEvent(
+        current="judger", progress=1.0, message="vLLM 服务已启动",
+        data={"base_url": state["judger"]["eval_base_url"]}))
+    return state
+
+
+def _step_format_data(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """可选的数据格式转换步骤（human-eval、mbpp 等）。"""
+    from loopai.agents.Judger.utils.oj.format import data_format
+
+    judger = state.get("judger", {})
+    format_type = judger.get("eval_format_type")
+
+    if format_type and format_type != "":
+        problem_path = judger.get("eval_problem_path", "")
+        task_id = state.get("task_id")
+        output_dir = Path(state.get("output_dir", "."))
+        file_stem = Path(problem_path).stem
+        target = output_dir / str(task_id) / "judger" / f"{file_stem}_format.jsonl"
+
+        writer(StreamEvent(
+            current="judger", progress=0.0,
+            message=f"正在进行数据格式转换 [{format_type}]"))
+        data_format(state)
+        state["judger"]["eval_problem_path"] = str(target)
+        writer(StreamEvent(
+            current="judger", progress=1.0, message="数据格式转换完成",
+            data={"target": str(target)}))
+    else:
+        writer(StreamEvent(
+            current="judger", progress=1.0,
+            message="未设置 format_type，跳过数据格式化"))
+
+    state["judger"]["output_problem_path"] = state["judger"]["eval_problem_path"]
+    return state
+
+
+def _step_generate(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """样本生成步骤：调用 vLLM 批量生成 code/text2sql 样本。"""
+    task_type = state.get("judger", {}).get("eval_task_type", "code")
+    batch_size = state.get("judger", {}).get("eval_batch_size", 10)
+    case_num = state.get("judger", {}).get("eval_case_num", 10)
+
+    writer(StreamEvent(
+        current="judger", progress=0.0,
+        message=f"开始生成样本 [task_type={task_type}]",
+        data={"batch_size": batch_size, "case_num": case_num}))
+
+    if task_type == "code":
+        from loopai.agents.Judger.utils.oj.generate import generate_sample_code
+        result_path = generate_sample_code(state)
+    elif task_type == "text2sql":
+        from loopai.agents.Judger.utils.oj.generate import generate_sample_text2sql
+        result_path = generate_sample_text2sql(state)
+    else:
+        raise ValueError(f"Unsupported task type for generate step: {task_type}")
+
+    state["judger"]["output_case_path"] = result_path
+    writer(StreamEvent(
+        current="judger", progress=1.0, message="样本生成完成",
+        data={"output_case_path": result_path}))
+    return state
+
+
+def _step_evaluate(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """样本评测步骤：执行代码/执行 SQL，计算 pass@k。"""
+    task_type = state.get("judger", {}).get("eval_task_type", "code")
+
+    writer(StreamEvent(
+        current="judger", progress=0.0,
+        message=f"开始评测样本 [task_type={task_type}]"))
+
+    if task_type == "code":
+        from loopai.agents.Judger.utils.oj.evaluate import evaluate_sample_code
+        result = evaluate_sample_code(state)
+    elif task_type == "text2sql":
+        from loopai.agents.Judger.utils.oj.evaluate import evaluate_sample_text2sql
+        result = evaluate_sample_text2sql(state)
+    else:
+        raise ValueError(f"Unsupported task type for evaluate step: {task_type}")
+
+    state["judger"]["output_result_path"] = result.get("result_path", "")
+    writer(StreamEvent(
+        current="judger", progress=1.0, message="评测完成",
+        data={"output_result_path": state["judger"]["output_result_path"]}))
+    return state
+
+
+def _step_eval_general_text(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """通用文本评测：One-Eval DataFlowEvalTool 子进程评测。
+
+    逻辑来自 ``loopai.skills.Judger.utils.eval_general_text``，
+    已去除 LangGraph 依赖，进度事件直接走传入的 ``writer``。
+    """
+    from loopai.skills.Judger.utils.eval_general_text import run_eval_general_text
+    return run_eval_general_text(state, writer)
+
+
+def _run_step(step_name: str, state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """分发执行单个流水线步骤。"""
+    step = normalize_judger_step(step_name)
+    dispatch = {
+        "validate": _step_validate,
+        "kill_vllm": _step_kill_vllm,
+        "start_vllm": _step_start_vllm,
+        "format_data": _step_format_data,
+        "generate": _step_generate,
+        "evaluate": _step_evaluate,
+        "kill_vllm_cleanup": _step_kill_vllm,
+        "eval_general_text": _step_eval_general_text,
+    }
+    if step in dispatch:
+        return dispatch[step](state, writer)
+    if step == "finish":
+        return state
+    raise ValueError(f"Unknown executable Judger step: {step_name}")
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline runner / 主流水线执行器
+# ---------------------------------------------------------------------------
+
+def run_judger_pipeline(
+    state: Optional[Dict[str, Any]],
+    thread_id: str = "judger-default",
+    checkpoint_path: Optional[str] = None,
+    resume: bool = False,
+    from_step: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """执行 Judger 独立函数流水线（无需 LangGraph）。
+
+    根据 task_type 自动选择流水线路径（code/text2sql 或 general_text）。
+
+    事件通过 ``loopai.common.event_tool.get_event_writer`` 持久化到
+    ``<output_dir>/<task_id>/judger.pkl``，事后可用 ``load_events()`` 读取。
+
+    Args:
+        state: 包含 ``state["judger"]`` 配置的状态字典。
+        thread_id: checkpoint 和事件的上下文 ID（= task_id）。
+        checkpoint_path: SQLite checkpoint 文件路径。
+        resume: 从 checkpoint 恢复执行。
+        from_step: 强制从指定步骤开始。
+        **kwargs: 运行时覆盖参数。
+
+    Returns:
+        最终状态字典。
+    """
+    from .runtime_config import resolve_judger_runtime_config
+
+    if checkpoint_path is None:
+        checkpoint_path = os.getenv(
+            "JUDGER_CHECKPOINT_PATH", "outputs/judger_checkpoints.sqlite"
+        )
+
+    # 加载或初始化 state
+    if resume:
+        state = load_judger_checkpoint(thread_id, checkpoint_path)
+        resolve_judger_runtime_config(state, thread_id=thread_id, **kwargs)
+    elif state is None:
+        raise ValueError("state is required when resume is False.")
+    else:
+        state = dict(state) if state is not None else {}
+        state.setdefault("judger", {})
+        resolve_judger_runtime_config(state, thread_id=thread_id, **kwargs)
+
+    output_dir = state.get("output_dir", "./outputs")
+
+    # ---- 创建事件写入器 ----
+    writer = get_event_writer(
+        name="judger",
+        context_id=thread_id,
+        log_file_path=output_dir,
+    )
+    writer(StreamEvent(
+        current="judger", progress=0.0, message="Judger pipeline started",
+        data={"task_id": thread_id, "resume": resume,
+              "task_type": (state.get("judger") or {}).get("eval_task_type")}))
+
+    # 根据任务类型选择流水线
+    task_type = (state.get("judger") or {}).get("eval_task_type", "code")
+    steps = _GENERAL_TEXT_STEPS if task_type == "general_text" else _CODE_TEXTSQL_STEPS
+
+    judger_cfg = state.get("judger") or {}
+    logger.info(f"[Judger] task_id={thread_id} task_type={task_type} "
+                f"pipeline={' -> '.join(steps)}")
+    logger.info(f"[Judger] model_path={judger_cfg.get('eval_model_path')} "
+                f"problem_path={judger_cfg.get('eval_problem_path')} "
+                f"batch_size={judger_cfg.get('eval_batch_size')} "
+                f"case_num={judger_cfg.get('eval_case_num')} "
+                f"gpu={judger_cfg.get('cuda_visible_devices')} "
+                f"tp_size={judger_cfg.get('eval_vllm_tensor_parallel_size')}")
+
+    # 确定起始步骤
+    if from_step is not None:
+        start_step = normalize_judger_step(from_step)
+    elif resume:
+        start_step = _resume_step_from_state(state)
+    else:
+        start_step = steps[0]
+
+    if start_step is None:
+        start_step = steps[0]
+    start_at = _start_index(start_step, steps)
+
+    if from_step is None and _is_finished(state):
+        logger.info(f"[Judger] already finished, skip")
+        return state
+
+    # 按序执行各步骤
+    state["current"] = "judger"  # agent 身份标识，全程不变
+    for i, step_name in enumerate(steps[start_at:], start_at):
+        logger.info(f"[Judger] step [{i+1}/{len(steps)}] {step_name} starting...")
+        save_judger_checkpoint(state, thread_id, checkpoint_path)
+
+        writer(StreamEvent(
+            current="judger", progress=0.0,
+            message=f"步骤开始: {step_name}"))
+
+        if step_name == "finish":
+            state["last_completed"] = "finish"
+            save_judger_checkpoint(state, thread_id, checkpoint_path)
+            writer(StreamEvent(
+                current="judger", progress=1.0, message="流水线完成"))
+            logger.info(f"[Judger] pipeline finished")
+            return state
+
+        state = _run_step(step_name, state, writer)
+        state["last_completed"] = step_name
+        save_judger_checkpoint(state, thread_id, checkpoint_path)
+
+        logger.info(f"[Judger] step [{i+1}/{len(steps)}] {step_name} done")
+        writer(StreamEvent(
+            current="judger", progress=1.0,
+            message=f"步骤完成: {step_name}"))
+
+    return state

--- a/loopai/skills/Judger/runner.py
+++ b/loopai/skills/Judger/runner.py
@@ -485,7 +485,7 @@ def _run_step(step_name: str, state: Dict[str, Any], writer) -> Dict[str, Any]:
 
 def run_judger_pipeline(
     state: Optional[Dict[str, Any]],
-    thread_id: str = "judger-default",
+    thread_id: Optional[str] = None,
     checkpoint_path: Optional[str] = None,
     resume: bool = False,
     from_step: Optional[str] = None,
@@ -530,6 +530,15 @@ def run_judger_pipeline(
         state = dict(state) if state is not None else {}
         state.setdefault("judger", {})
         resolve_judger_runtime_config(state, thread_id=thread_id, **kwargs)
+
+    # thread_id 优先用显式传参，回退到 state["task_id"]（runtime_config 解析结果）
+    thread_id = thread_id or state.get("task_id") or ""
+    if not thread_id:
+        emit_error(
+            ValueError("task_id is required but was not provided."),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message="Please provide --task-id or set TASK_ID env var.",
+        )
 
     output_dir = state.get("output_dir", "./outputs")
 

--- a/loopai/skills/Judger/runtime_config.py
+++ b/loopai/skills/Judger/runtime_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, Optional
 
-_DEFAULT_THREAD_ID = "judger-default"
 _DEFAULT_OUTPUT_DIR = "./outputs"
 
 # JudgerState schema defaults (mirror loopai/schema/states.py JudgerState)
@@ -161,7 +160,7 @@ def resolve_judger_runtime_config(
         kwargs.get("task_id"),
         os.getenv("TASK_ID"),
         state.get("task_id") if is_state_dict else None,
-        _DEFAULT_THREAD_ID,
+        # 不设兜底值：task_id 缺失时 _step_validate 会报 CONFIG_ERROR
     )
     output_dir = _first_non_empty(
         kwargs.get("output_dir"),
@@ -229,7 +228,7 @@ def resolve_judger_runtime_config(
             state["DB_PATH"] = db_path
 
     return {
-        "thread_id": str(task_id or _DEFAULT_THREAD_ID),
+        "thread_id": str(task_id) if task_id else "",
         "output_dir": str(output_dir or _DEFAULT_OUTPUT_DIR),
         "db_path": db_path,
         "model_path": model_path,

--- a/loopai/skills/Judger/runtime_config.py
+++ b/loopai/skills/Judger/runtime_config.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+_DEFAULT_THREAD_ID = "judger-default"
+_DEFAULT_OUTPUT_DIR = "./outputs"
+
+# JudgerState schema defaults (mirror loopai/schema/states.py JudgerState)
+_SCHEMA_DEFAULTS: Dict[str, Any] = {
+    "eval_task_type": "code",
+    "eval_temperature": 0,
+    "eval_top_p": 0.95,
+    "eval_batch_size": 10,
+    "eval_case_num": 10,
+    "eval_vllm_tensor_parallel_size": 2,
+    "eval_vllm_gpu_memory_utilization": 0.9,
+    "cuda_visible_devices": "0",
+    "bench_name": "general_text_eval",
+    "bench_dataflow_eval_type": "",
+    "key_mapping": {},
+}
+
+
+def _first_non_empty(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _judger(state: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(state, dict):
+        return {}
+    judger = state.setdefault("judger", {})
+    if not isinstance(judger, dict):
+        state["judger"] = {}
+        return state["judger"]
+    return judger
+
+
+def resolve_judger_runtime_config(
+    state: Optional[Dict[str, Any]],
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Resolve Judger runtime values from kwargs, env, state, defaults.
+
+    Priority: kwargs > env > state["judger"] > schema defaults.
+
+    Returns a flat dict with resolved keys suitable for the standalone runner.
+    """
+    judger = _judger(state)
+    is_state_dict = isinstance(state, dict)
+
+    # --- model / vllm ---
+    model_path = _first_non_empty(
+        kwargs.get("judger_model_path"),
+        kwargs.get("model_path"),
+        os.getenv("JUDGER_MODEL_PATH"),
+        judger.get("eval_model_path"),
+    )
+    task_type = _first_non_empty(
+        kwargs.get("judger_task_type"),
+        kwargs.get("task_type"),
+        os.getenv("JUDGER_TASK_TYPE"),
+        judger.get("eval_task_type"),
+        _SCHEMA_DEFAULTS["eval_task_type"],
+    )
+    temperature = _first_non_empty(
+        kwargs.get("judger_temperature"),
+        os.getenv("JUDGER_TEMPERATURE"),
+        judger.get("eval_temperature"),
+        _SCHEMA_DEFAULTS["eval_temperature"],
+    )
+    top_p = _first_non_empty(
+        kwargs.get("judger_top_p"),
+        os.getenv("JUDGER_TOP_P"),
+        judger.get("eval_top_p"),
+        _SCHEMA_DEFAULTS["eval_top_p"],
+    )
+    problem_path = _first_non_empty(
+        kwargs.get("judger_problem_path"),
+        kwargs.get("problem_path"),
+        os.getenv("JUDGER_PROBLEM_PATH"),
+        judger.get("eval_problem_path"),
+    )
+    batch_size = _first_non_empty(
+        kwargs.get("judger_batch_size"),
+        os.getenv("JUDGER_BATCH_SIZE"),
+        judger.get("eval_batch_size"),
+        _SCHEMA_DEFAULTS["eval_batch_size"],
+    )
+    case_num = _first_non_empty(
+        kwargs.get("judger_case_num"),
+        os.getenv("JUDGER_CASE_NUM"),
+        judger.get("eval_case_num"),
+        _SCHEMA_DEFAULTS["eval_case_num"],
+    )
+
+    # --- optional: format / data ---
+    format_type = _first_non_empty(
+        kwargs.get("judger_format_type"),
+        os.getenv("JUDGER_FORMAT_TYPE"),
+        judger.get("eval_format_type"),
+    )
+    text2sql_dir = _first_non_empty(
+        kwargs.get("judger_text2sql_dir"),
+        os.getenv("JUDGER_TEXT2SQL_DIR"),
+        judger.get("eval_text2sql_dir"),
+    )
+
+    # --- vllm local startup ---
+    tensor_parallel_size = _first_non_empty(
+        kwargs.get("judger_tensor_parallel_size"),
+        os.getenv("JUDGER_TENSOR_PARALLEL_SIZE"),
+        judger.get("eval_vllm_tensor_parallel_size"),
+        judger.get("tensor_parallel_size"),  # 兼容 starter.yaml 中的短键名
+        _SCHEMA_DEFAULTS["eval_vllm_tensor_parallel_size"],
+    )
+    gpu_memory_utilization = _first_non_empty(
+        kwargs.get("judger_gpu_memory_utilization"),
+        os.getenv("JUDGER_GPU_MEMORY_UTILIZATION"),
+        judger.get("eval_vllm_gpu_memory_utilization"),
+        _SCHEMA_DEFAULTS["eval_vllm_gpu_memory_utilization"],
+    )
+    cuda_visible_devices = _first_non_empty(
+        kwargs.get("cuda_visible_devices"),
+        os.getenv("CUDA_VISIBLE_DEVICES"),
+        judger.get("cuda_visible_devices"),
+        _SCHEMA_DEFAULTS["cuda_visible_devices"],
+    )
+
+    # --- general_text ---
+    bench_name = _first_non_empty(
+        kwargs.get("judger_bench_name"),
+        os.getenv("JUDGER_BENCH_NAME"),
+        judger.get("bench_name"),
+        _SCHEMA_DEFAULTS["bench_name"],
+    )
+    bench_dataflow_eval_type = _first_non_empty(
+        kwargs.get("judger_bench_dataflow_eval_type"),
+        os.getenv("JUDGER_BENCH_DATAFLOW_EVAL_TYPE"),
+        judger.get("bench_dataflow_eval_type"),
+        _SCHEMA_DEFAULTS["bench_dataflow_eval_type"],
+    )
+    key_mapping = _first_non_empty(
+        kwargs.get("judger_key_mapping"),
+        judger.get("key_mapping"),
+        _SCHEMA_DEFAULTS["key_mapping"],
+    )
+    if isinstance(key_mapping, str):
+        import json
+        try:
+            key_mapping = json.loads(key_mapping)
+        except (json.JSONDecodeError, TypeError):
+            key_mapping = {}
+
+    # --- global ---
+    task_id = _first_non_empty(
+        kwargs.get("thread_id"),
+        kwargs.get("task_id"),
+        os.getenv("TASK_ID"),
+        state.get("task_id") if is_state_dict else None,
+        _DEFAULT_THREAD_ID,
+    )
+    output_dir = _first_non_empty(
+        kwargs.get("output_dir"),
+        os.getenv("OUTPUT_DIR"),
+        state.get("output_dir") if is_state_dict else None,
+        _DEFAULT_OUTPUT_DIR,
+    )
+    db_path = _first_non_empty(
+        kwargs.get("db_path"),
+        os.getenv("DB_PATH"),
+    )
+
+    # --- type coercion ---
+    try:
+        temperature = float(temperature) if temperature is not None else 0.0
+    except (TypeError, ValueError):
+        temperature = 0.0
+    try:
+        top_p = float(top_p) if top_p is not None else 0.95
+    except (TypeError, ValueError):
+        top_p = 0.95
+    try:
+        batch_size = int(batch_size) if batch_size is not None else 10
+    except (TypeError, ValueError):
+        batch_size = 10
+    try:
+        case_num = int(case_num) if case_num is not None else 10
+    except (TypeError, ValueError):
+        case_num = 10
+    try:
+        tensor_parallel_size = int(tensor_parallel_size) if tensor_parallel_size is not None else 2
+    except (TypeError, ValueError):
+        tensor_parallel_size = 2
+    try:
+        gpu_memory_utilization = float(gpu_memory_utilization) if gpu_memory_utilization is not None else 0.9
+    except (TypeError, ValueError):
+        gpu_memory_utilization = 0.9
+
+    # --- write resolved values back into state ---
+    if is_state_dict:
+        if task_id and not state.get("task_id"):
+            state["task_id"] = task_id
+        if output_dir:
+            state["output_dir"] = output_dir
+
+        state["judger"]["eval_model_path"] = model_path
+        state["judger"]["eval_task_type"] = task_type
+        state["judger"]["eval_temperature"] = temperature
+        state["judger"]["eval_top_p"] = top_p
+        state["judger"]["eval_problem_path"] = problem_path
+        state["judger"]["eval_batch_size"] = batch_size
+        state["judger"]["eval_case_num"] = case_num
+        if format_type is not None:
+            state["judger"]["eval_format_type"] = format_type
+        if text2sql_dir is not None:
+            state["judger"]["eval_text2sql_dir"] = text2sql_dir
+        state["judger"]["eval_vllm_tensor_parallel_size"] = tensor_parallel_size
+        state["judger"]["eval_vllm_gpu_memory_utilization"] = gpu_memory_utilization
+        state["judger"]["cuda_visible_devices"] = cuda_visible_devices
+        state["judger"]["bench_name"] = bench_name
+        state["judger"]["bench_dataflow_eval_type"] = bench_dataflow_eval_type
+        state["judger"]["key_mapping"] = key_mapping
+        if db_path:
+            state["DB_PATH"] = db_path
+
+    return {
+        "thread_id": str(task_id or _DEFAULT_THREAD_ID),
+        "output_dir": str(output_dir or _DEFAULT_OUTPUT_DIR),
+        "db_path": db_path,
+        "model_path": model_path,
+        "task_type": str(task_type),
+        "temperature": temperature,
+        "top_p": top_p,
+        "problem_path": problem_path,
+        "batch_size": batch_size,
+        "case_num": case_num,
+        "format_type": format_type,
+        "text2sql_dir": text2sql_dir,
+        "tensor_parallel_size": tensor_parallel_size,
+        "gpu_memory_utilization": gpu_memory_utilization,
+        "cuda_visible_devices": str(cuda_visible_devices),
+        "bench_name": str(bench_name),
+        "bench_dataflow_eval_type": str(bench_dataflow_eval_type or ""),
+        "key_mapping": key_mapping if isinstance(key_mapping, dict) else {},
+    }

--- a/loopai/skills/Judger/runtime_config.py
+++ b/loopai/skills/Judger/runtime_config.py
@@ -202,7 +202,8 @@ def resolve_judger_runtime_config(
 
     # --- write resolved values back into state ---
     if is_state_dict:
-        if task_id and not state.get("task_id"):
+        # CLI/env 传入的 task_id 优先级高于 YAML 默认值，始终覆盖
+        if task_id:
             state["task_id"] = task_id
         if output_dir:
             state["output_dir"] = output_dir

--- a/loopai/skills/Judger/utils/eval_general_text.py
+++ b/loopai/skills/Judger/utils/eval_general_text.py
@@ -19,6 +19,7 @@ from one_eval.toolkits.dataflow_eval_tool import DataFlowEvalTool
 from one_eval.core.state import ModelConfig
 from loopai.agents.Judger.utils.oj.const import field_mapping
 from loopai.common.event_tool import StreamEvent
+from loopai.common.exception import emit_error, ErrorCode
 from loopai.logger import get_logger
 
 logger = get_logger()
@@ -250,14 +251,24 @@ def run_eval_general_text(state: Dict[str, Any], writer) -> Dict[str, Any]:
     # 校验必填字段
     eval_result_path = cfg.get("eval_problem_path")
     if not eval_result_path:
-        raise ValueError("缺少评测输入路径：请提供 judger.eval_problem_path")
+        emit_error(
+            ValueError("缺少评测输入路径：请提供 judger.eval_problem_path"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message="Missing judger.eval_problem_path for general_text evaluation.",
+        )
     if not os.path.exists(eval_result_path):
-        raise FileNotFoundError(f"评测输入路径不存在：{eval_result_path}")
+        emit_error(
+            FileNotFoundError(f"评测输入路径不存在：{eval_result_path}"),
+            code=ErrorCode.NOT_FOUND, recoverable=True,
+            message=f"Problem file not found: {eval_result_path}",
+        )
 
     eval_type = cfg.get("bench_dataflow_eval_type")
     if not eval_type:
-        raise ValueError(
-            "通用文本评测缺少 eval_type。请在 judger.bench_dataflow_eval_type 中提供"
+        emit_error(
+            ValueError("通用文本评测缺少 eval_type。请在 judger.bench_dataflow_eval_type 中提供"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message="Missing judger.bench_dataflow_eval_type for general_text evaluation.",
         )
 
     logger.info(f"[Judger/general_text] model={cfg.get('eval_model_path')} "
@@ -315,9 +326,17 @@ def run_eval_general_text(state: Dict[str, Any], writer) -> Dict[str, Any]:
         data={"bench_name": bench_name, "eval_type": eval_type}))
 
     if not bench.dataset_cache:
-        raise ValueError(f"[{bench_name}] 缺少 dataset_cache")
+        emit_error(
+            ValueError(f"[{bench_name}] 缺少 dataset_cache"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message=f"Bench '{bench_name}' is missing dataset_cache.",
+        )
     if not bench.bench_dataflow_eval_type:
-        raise ValueError(f"[{bench_name}] 缺少 eval_type")
+        emit_error(
+            ValueError(f"[{bench_name}] 缺少 eval_type"),
+            code=ErrorCode.CONFIG_ERROR, recoverable=True,
+            message=f"Bench '{bench_name}' is missing bench_dataflow_eval_type.",
+        )
 
     # 子进程执行 DataFlowEvalTool
     bench.eval_status = "running"
@@ -360,13 +379,17 @@ def run_eval_general_text(state: Dict[str, Any], writer) -> Dict[str, Any]:
             try:
                 payload = result_queue.get_nowait()
             except pyqueue.Empty:
-                raise RuntimeError(
-                    f"[{bench_name}] run_eval 子进程未返回结果, exitcode={proc.exitcode}"
+                emit_error(
+                    RuntimeError(f"[{bench_name}] run_eval 子进程未返回结果"),
+                    code=ErrorCode.EXTERNAL_SERVICE_ERROR, recoverable=True,
+                    message=f"DataFlowEvalTool subprocess (pid={proc.pid}) exited without returning a result.",
                 )
         if not payload.get("ok"):
-            raise RuntimeError(
-                f"{payload.get('error', 'run_eval failed')}\n"
-                f"{payload.get('traceback', '')}"
+            emit_error(
+                RuntimeError(f"{payload.get('error', 'run_eval failed')}\n"
+                             f"{payload.get('traceback', '')}"),
+                code=ErrorCode.EXTERNAL_SERVICE_ERROR, recoverable=True,
+                message=f"DataFlowEvalTool subprocess evaluation failed.",
             )
 
         result = payload["result"]

--- a/loopai/skills/Judger/utils/eval_general_text.py
+++ b/loopai/skills/Judger/utils/eval_general_text.py
@@ -1,0 +1,456 @@
+# -*- coding: utf-8 -*-
+"""Standalone general_text evaluation — no LangGraph dependency.
+
+Extracted from ``loopai.agents.Judger.nodes.eval_general_text_node``,
+replaced ``get_stream_writer()`` with a passed-in ``writer`` parameter.
+"""
+
+import json
+import os
+import time
+import traceback
+import multiprocessing as mp
+import queue as pyqueue
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from one_eval.toolkits.dataflow_eval_tool import DataFlowEvalTool
+from one_eval.core.state import ModelConfig
+from loopai.agents.Judger.utils.oj.const import field_mapping
+from loopai.common.event_tool import StreamEvent
+from loopai.logger import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class BenchAdapter:
+    bench_name: str
+    dataset_cache: str
+    bench_dataflow_eval_type: str
+    eval_status: str = "pending"
+    meta: Dict[str, Any] = field(default_factory=dict)
+    key_mapping: Dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+def _read_jsonl(path: str) -> List[Dict[str, Any]]:
+    rows = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, Any]]):
+    with open(path, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+
+def _build_model_config(cfg: Dict[str, Any]) -> ModelConfig:
+    return ModelConfig(
+        model_name_or_path=cfg.get("eval_model_path") or "dummy",
+        is_api=bool(cfg.get("is_api", False)),
+        api_url=cfg.get("eval_base_url", ""),
+        api_key=cfg.get("eval_api_key", "EMPTY"),
+        temperature=float(cfg.get("eval_temperature", 0.0)),
+        top_p=float(cfg.get("eval_top_p", 1.0)),
+        tensor_parallel_size=int(cfg.get("eval_vllm_tensor_parallel_size", 1)),
+        max_tokens=int(cfg.get("eval_max_tokens", cfg.get("max_tokens", 2048))),
+        gpu_memory_utilization=cfg.get("eval_vllm_gpu_memory_utilization", 0.9),
+    )
+
+
+def _generate_key_mapping(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    key_mapping: Dict[str, Any] = {}
+    eval_type = cfg["bench_dataflow_eval_type"]
+    eval_problem_path = cfg["eval_problem_path"]
+    count = 0
+    with open(eval_problem_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            keys = list(data.keys())
+            for key in keys:
+                if eval_type == "key1_text_score":
+                    if key in field_mapping["text"]:
+                        key_mapping["input_text_key"] = key
+                else:
+                    if key in field_mapping["question"]:
+                        key_mapping["input_question_key"] = key
+                    elif eval_type == "key2_qa":
+                        if key in field_mapping["target"]:
+                            key_mapping["input_target_key"] = key
+                        elif key in field_mapping["prediction"]:
+                            key_mapping["input_pred_key"] = key
+                    elif eval_type == "key2_q_ma":
+                        if key in field_mapping["targets"]:
+                            key_mapping["input_targets_key"] = key
+                        elif key in field_mapping["prediction"]:
+                            key_mapping["input_pred_key"] = key
+                    elif eval_type == "key3_q_choices_a":
+                        if key in field_mapping["choices"]:
+                            key_mapping["input_choices_key"] = key
+                        elif key in field_mapping["label"]:
+                            key_mapping["input_label_key"] = key
+                    elif eval_type == "key3_q_choices_as":
+                        if key in field_mapping["choices"]:
+                            key_mapping["input_choices_key"] = key
+                        elif key in field_mapping["labels"]:
+                            key_mapping["input_labels_key"] = key
+                    elif eval_type == "key3_q_a_rejected":
+                        if key in field_mapping["answer"]:
+                            key_mapping["input_answer_key"] = key
+                        elif key in field_mapping["rejected"]:
+                            key_mapping["input_rejected_key"] = key
+                        elif key in field_mapping["better"]:
+                            key_mapping["input_better_key"] = key
+            count += 1
+            if count == 2:
+                break
+    return key_mapping
+
+
+def _infer_pred_ref_keys(
+    eval_type: str, final_key_mapping: Dict[str, Any]
+) -> Dict[str, Optional[str]]:
+    default_pred_key = "generated_ans"
+    pred_key = final_key_mapping.get("input_pred_key") or default_pred_key
+    ref_key: Optional[str] = None
+    if eval_type == "key2_qa":
+        ref_key = final_key_mapping.get("input_target_key")
+    elif eval_type == "key2_q_ma":
+        ref_key = final_key_mapping.get("input_targets_key")
+    elif eval_type == "key3_q_choices_a":
+        ref_key = final_key_mapping.get("input_label_key")
+        pred_key = "eval_pred"
+    elif eval_type == "key3_q_choices_as":
+        ref_key = final_key_mapping.get("input_labels_key")
+        pred_key = "eval_pred"
+    elif eval_type == "key3_q_a_rejected":
+        ref_key = final_key_mapping.get("input_better_key")
+    elif eval_type == "key1_text_score":
+        ref_key = None
+        if final_key_mapping.get("input_text_key"):
+            pred_key = final_key_mapping.get("input_text_key")
+    return {"pred_key": pred_key, "ref_key": ref_key}
+
+
+def _build_summary_payload(
+    run_ts: str,
+    result: Dict[str, Any],
+    bench: BenchAdapter,
+    dataset_cache_path: str,
+) -> Dict[str, Any]:
+    stats = result.get("stats") or {}
+    return {
+        "run_ts": run_ts,
+        "task_type": bench.bench_dataflow_eval_type,
+        "bench_name": bench.bench_name,
+        "bench_dataflow_eval_type": bench.bench_dataflow_eval_type,
+        "dataset_cache": dataset_cache_path,
+        "detail_path": result.get("detail_path"),
+        "key_mapping": result.get("key_mapping") or {},
+        "stats": stats,
+        "num_samples": (
+            stats.get("total_samples")
+            if stats.get("total_samples") is not None
+            else stats.get("valid_samples", 0)
+        ),
+        "average": stats,
+    }
+
+
+def _write_summary_files(
+    outdir: Path, summary: Dict[str, Any], run_ts: str
+) -> tuple:
+    summary_json = outdir / f"text_eval_summary_{run_ts}.json"
+    summary_txt = outdir / f"text_eval_summary_{run_ts}.txt"
+    with open(summary_json, "w", encoding="utf-8") as f:
+        json.dump(summary, f, ensure_ascii=False, indent=2)
+    stats = summary.get("stats") or {}
+    lines = [
+        f"评测时间：{run_ts}",
+        f"bench_name：{summary.get('bench_name')}",
+        f"eval_type：{summary.get('bench_dataflow_eval_type')}",
+        f"dataset_cache：{summary.get('dataset_cache')}",
+        f"detail_path：{summary.get('detail_path')}",
+        "统计结果：",
+    ]
+    for k, v in stats.items():
+        lines.append(f"  - {k}: {v}")
+    with open(summary_txt, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    return str(summary_json.resolve()), str(summary_txt.resolve())
+
+
+def _run_eval_in_subprocess(
+    output_root: str,
+    bench: BenchAdapter,
+    model_config: ModelConfig,
+    result_queue: mp.Queue,
+):
+    try:
+        logger.info("==== DataFlowEvalTool runEval starting ====")
+        tool = DataFlowEvalTool(output_root=output_root)
+        result = tool.run_eval(bench, model_config)
+        tool.release_serving()
+        logger.info("==== Released vLLM serving after workflow ====")
+        result_queue.put({
+            "ok": True,
+            "result": result,
+            "bench_meta": bench.meta,
+            "bench_key_mapping": bench.key_mapping,
+            "eval_status": bench.eval_status,
+        })
+    except Exception as exc:
+        result_queue.put({
+            "ok": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        })
+
+
+# ---------------------------------------------------------------------------
+# 主入口
+# ---------------------------------------------------------------------------
+
+def run_eval_general_text(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """通用文本评测（One-Eval DataFlowEvalTool），无 LangGraph 依赖。
+
+    进度事件通过 ``writer`` 发送（PickleEventWriter），
+    评测结果存入 ``state["judger"]["bench"]`` 和 ``output_result_path``。
+    """
+    os.environ["CUDA_VISIBLE_DEVICES"] = (state.get("judger") or {}).get(
+        "cuda_visible_devices", "2"
+    )
+
+    cfg: Dict[str, Any] = state.get("judger") or {}
+    outdir = (
+        Path(state.get("output_dir") or "./outputs")
+        / (state.get("task_id") or "default_task")
+        / "judger"
+    )
+    outdir.mkdir(parents=True, exist_ok=True)
+    run_ts = time.strftime("%Y%m%d_%H%M%S")
+
+    # 校验必填字段
+    eval_result_path = cfg.get("eval_problem_path")
+    if not eval_result_path:
+        raise ValueError("缺少评测输入路径：请提供 judger.eval_problem_path")
+    if not os.path.exists(eval_result_path):
+        raise FileNotFoundError(f"评测输入路径不存在：{eval_result_path}")
+
+    eval_type = cfg.get("bench_dataflow_eval_type")
+    if not eval_type:
+        raise ValueError(
+            "通用文本评测缺少 eval_type。请在 judger.bench_dataflow_eval_type 中提供"
+        )
+
+    logger.info(f"[Judger/general_text] model={cfg.get('eval_model_path')} "
+                f"eval_type={eval_type} gpu={cfg.get('cuda_visible_devices')} "
+                f"tp_size={cfg.get('eval_vllm_tensor_parallel_size', 1)} "
+                f"problem_path={eval_result_path}")
+
+    # 解析 key_mapping
+    key_mapping = cfg.get("key_mapping") or {}
+    if isinstance(key_mapping, str):
+        try:
+            key_mapping = json.loads(key_mapping)
+        except Exception:
+            key_mapping = _generate_key_mapping(cfg)
+    if not key_mapping:
+        key_mapping = _generate_key_mapping(cfg)
+
+    bench_name = cfg.get("bench_name") or "general_text_eval"
+
+    writer(StreamEvent(
+        current="judger", progress=0.0,
+        message="开始通用文本评测 (One-Eval)",
+        data={"bench_name": bench_name, "eval_type": eval_type}))
+
+    # 读取待评测样本
+    rows = _read_jsonl(eval_result_path)
+    writer(StreamEvent(
+        current="judger", progress=0.1, message="读取待评测样本完成",
+        data={"records": len(rows)}))
+
+    # 生成 dataset_cache
+    dataset_cache_path = outdir / f"general_text_dataset_cache_{run_ts}.jsonl"
+    _write_jsonl(dataset_cache_path, rows)
+    dataset_cache_path_s = str(dataset_cache_path.resolve())
+    state["judger"]["output_problem_path"] = dataset_cache_path_s
+    writer(StreamEvent(
+        current="judger", progress=0.2, message="已生成 dataset_cache",
+        data={"output_problem_path": dataset_cache_path_s}))
+
+    # 构造 bench 和 model_config
+    bench = BenchAdapter(
+        bench_name=bench_name,
+        dataset_cache=dataset_cache_path_s,
+        bench_dataflow_eval_type=eval_type,
+        meta={},
+        key_mapping=key_mapping or {},
+    )
+    if key_mapping:
+        bench.meta["key_mapping"] = key_mapping
+
+    model_config = _build_model_config(cfg)
+    writer(StreamEvent(
+        current="judger", progress=0.35,
+        message="One-Eval 配置完成，正在调用 DataFlowEvalTool",
+        data={"bench_name": bench_name, "eval_type": eval_type}))
+
+    if not bench.dataset_cache:
+        raise ValueError(f"[{bench_name}] 缺少 dataset_cache")
+    if not bench.bench_dataflow_eval_type:
+        raise ValueError(f"[{bench_name}] 缺少 eval_type")
+
+    # 子进程执行 DataFlowEvalTool
+    bench.eval_status = "running"
+    if getattr(bench, "key_mapping", None):
+        bench.meta["key_mapping"] = bench.key_mapping
+    elif (bench.meta or {}).get("key_mapping"):
+        bench.key_mapping = bench.meta["key_mapping"]
+
+    result_queue: mp.Queue = mp.Queue()
+    proc = mp.Process(
+        target=_run_eval_in_subprocess,
+        args=(str(outdir), bench, model_config, result_queue),
+        daemon=False,
+    )
+    proc.start()
+    logger.info(f"[Judger/general_text] DataFlowEvalTool subprocess started "
+                f"pid={proc.pid}")
+    writer(StreamEvent(
+        current="judger", progress=0.5,
+        message="DataFlowEvalTool 子进程已启动，等待评测完成",
+        data={"pid": proc.pid}))
+
+    try:
+        wait_start = time.time()
+        payload = None
+        while proc.is_alive():
+            try:
+                payload = result_queue.get_nowait()
+                break
+            except pyqueue.Empty:
+                pass
+            proc.join(timeout=5)
+            if proc.is_alive():
+                elapsed = int(time.time() - wait_start)
+                writer(StreamEvent(
+                    current="judger", progress=0.55,
+                    message="DataFlowEvalTool 子进程仍在运行",
+                    data={"pid": proc.pid, "waited_seconds": elapsed}))
+        if payload is None:
+            try:
+                payload = result_queue.get_nowait()
+            except pyqueue.Empty:
+                raise RuntimeError(
+                    f"[{bench_name}] run_eval 子进程未返回结果, exitcode={proc.exitcode}"
+                )
+        if not payload.get("ok"):
+            raise RuntimeError(
+                f"{payload.get('error', 'run_eval failed')}\n"
+                f"{payload.get('traceback', '')}"
+            )
+
+        result = payload["result"]
+        bench.meta = payload.get("bench_meta", bench.meta)
+        bench.key_mapping = payload.get("bench_key_mapping", bench.key_mapping)
+        bench.eval_status = payload.get("eval_status", bench.eval_status)
+    finally:
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=3)
+            if proc.is_alive():
+                proc.kill()
+                proc.join(timeout=3)
+        result_queue.cancel_join_thread()
+        result_queue.close()
+
+    writer(StreamEvent(
+        current="judger", progress=0.7,
+        message="DataFlowEvalTool 子进程完成，生成评测结果"))
+
+    if not bench.meta:
+        bench.meta = {}
+    stats = result["stats"]
+    logger.info(f"[Judger/general_text] subprocess result: stats={stats}")
+    detail_path = result.get("detail_path")
+    bench.meta["eval_result"] = stats
+    bench.meta["eval_detail_path"] = detail_path
+
+    # 推断 pred_key / ref_key
+    final_key_mapping = result.get("key_mapping", {})
+    inferred = _infer_pred_ref_keys(eval_type, final_key_mapping)
+    if inferred["ref_key"]:
+        bench.meta["ref_key"] = inferred["ref_key"]
+    bench.meta["pred_key"] = inferred["pred_key"]
+    if final_key_mapping:
+        bench.meta["key_mapping"] = final_key_mapping
+        bench.key_mapping = final_key_mapping
+    bench.eval_status = "success"
+
+    # 检测异常零分
+    total_samples = stats.get("total_samples", 0)
+    if total_samples > 0 and stats.get("accuracy", 0) == 0 and stats.get("score", 0) == 0:
+        reason = "Score is 0. Possibly a hidden test set without public labels."
+        if stats.get("valid_samples", 0) == 0:
+            reason += " (No valid samples found for evaluation)"
+        bench.meta["eval_abnormality"] = {
+            "is_abnormal": True, "reason": reason, "type": "zero_score",
+        }
+
+    writer(StreamEvent(
+        current="judger", progress=0.8, message="等待评测结果...",
+        data={"output_pred_path": detail_path, "stats": stats}))
+
+    # 确定 detail 文件路径
+    if detail_path and os.path.exists(detail_path):
+        step2_file_path = str(Path(detail_path).resolve())
+    else:
+        fallback = outdir / f"text_eval_scored_{run_ts}.json"
+        with open(fallback, "w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+        step2_file_path = str(fallback.resolve())
+
+    # 写摘要文件
+    summary = _build_summary_payload(run_ts, result, bench, dataset_cache_path_s)
+    summary_json_path, summary_txt_path = _write_summary_files(outdir, summary, run_ts)
+
+    bench.meta.setdefault("artifact_paths", {})
+    bench.meta["artifact_paths"]["records_path"] = step2_file_path
+    bench.meta["eval_detail_path"] = step2_file_path
+
+    # 回写 state
+    state["judger"]["bench"] = {
+        "bench_name": bench.bench_name,
+        "dataset_cache": bench.dataset_cache,
+        "bench_dataflow_eval_type": bench.bench_dataflow_eval_type,
+        "eval_status": bench.eval_status,
+        "meta": bench.meta or {},
+        "key_mapping": bench.key_mapping or {},
+    }
+    state["judger"]["output_result_path"] = summary_json_path
+    state["judger"]["output_pred_path"] = step2_file_path
+
+    writer(StreamEvent(
+        current="judger", progress=1.0, message="通用文本评测完成",
+        data={"output_result_path": summary_json_path, "output_pred_path": step2_file_path}))
+
+    return state

--- a/loopai/skills/Judger/utils/evaluate.py
+++ b/loopai/skills/Judger/utils/evaluate.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+"""Standalone code/text2sql evaluation — no LangGraph dependency.
+
+Extracted from ``loopai.agents.Judger.utils.oj.evaluate``,
+replaced ``get_stream_writer()`` with a passed-in ``writer`` parameter.
+"""
+
+import itertools
+from collections import defaultdict, Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import tqdm
+
+from loopai.agents.Judger.utils.oj.data import write_jsonl, stream_jsonl, read_problems
+from loopai.agents.Judger.utils.oj.execution import check_correctness
+from loopai.agents.Judger.utils.oj.execution_sql import compare_sql_wrapper
+from loopai.common.event_tool import StreamEvent
+from loopai.logger import get_logger
+
+logger = get_logger()
+
+K = "1,10,100"
+N_WORKERS = 1
+TIMEOUT = 3.0
+
+
+def estimate_pass_at_k(
+    num_samples: Union[int, List[int], np.ndarray],
+    num_correct: Union[List[int], np.ndarray],
+    k: int,
+) -> np.ndarray:
+    def estimator(n: int, c: int, k: int) -> float:
+        if n - c < k:
+            return 1.0
+        return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
+
+    if isinstance(num_samples, int):
+        num_samples_it = itertools.repeat(num_samples, len(num_correct))
+    else:
+        assert len(num_samples) == len(num_correct)
+        num_samples_it = iter(num_samples)
+    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples_it, num_correct)])
+
+
+def _calculate_pass_at_k(k, results):
+    total, correct = [], []
+    for result in results.values():
+        result.sort()
+        passed = [r[1]["passed"] for r in result]
+        total.append(len(passed))
+        correct.append(sum(passed))
+    total = np.array(total)
+    correct = np.array(correct)
+    return {f"pass@{_k}": estimate_pass_at_k(total, correct, _k).mean()
+            for _k in k if (total >= _k).all()}
+
+
+def _write_evaluate_log(pass_at_k, result_path, test_case_path, problem_path):
+    file_path = Path(result_path).parent / "log.txt"
+    lines = [f"{key}: {value:.4f}" for key, value in pass_at_k.items()]
+    with open(file_path, "a", encoding="utf-8") as f:
+        f.write(f"\n\n--- {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ---")
+        f.write(f"\nSample:{test_case_path}")
+        f.write(f"\nProblem:{problem_path}")
+        f.write(f"\nResult:{result_path}")
+        f.write("\n" + "\n".join(lines))
+
+
+def run_evaluate_code(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """评测代码样本，返回 pass@k 和 result_path。"""
+    state_task_id = state.get("task_id")
+    judger_state = state.get("judger", {})
+    output_dir = Path(state.get("output_dir"))
+    problem_path = judger_state["eval_problem_path"]
+    problem_file_name = Path(problem_path).stem
+    test_case_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_sample.jsonl"
+    )
+    result_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_result.jsonl"
+    )
+    case_num = judger_state.get("eval_case_num", 10)
+    task_type = judger_state["eval_task_type"]
+
+    k = list(map(int, K.split(",")))
+    problems = read_problems(problem_path)
+    total_samples = len(problems) * case_num
+
+    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        futures = []
+        completion_id = Counter()
+        n_samples = 0
+        results = defaultdict(list)
+
+        logger.info("Reading samples...")
+        for sample in tqdm.tqdm(stream_jsonl(test_case_path)):
+            task_id = sample["task_id"]
+            completion = sample["completion"]
+            args = (problems[task_id], completion, TIMEOUT, completion_id[task_id])
+            futures.append(executor.submit(check_correctness, *args))
+            completion_id[task_id] += 1
+            n_samples += 1
+            writer(StreamEvent(
+                current="judger",
+                progress=round(n_samples / total_samples, 1),
+                message=f"{task_type}任务样本提交进度",
+                data={"progress_detail": f"{n_samples}/{total_samples}"}))
+
+        assert len(completion_id) == len(problems), "Some problems are not attempted."
+
+        n_samples2 = 0
+        logger.info("Running test suites...")
+        for future in tqdm.tqdm(as_completed(futures), total=len(futures)):
+            result = future.result()
+            results[result["task_id"]].append((result["completion_id"], result))
+            n_samples2 += 1
+            writer(StreamEvent(
+                current="judger",
+                progress=round(n_samples2 / total_samples, 1),
+                message=f"{task_type}任务样本评测进度",
+                data={"progress_detail": f"{n_samples2}/{total_samples}"}))
+
+    pass_at_k = _calculate_pass_at_k(k, results)
+
+    def combine_results():
+        for sample in stream_jsonl(test_case_path):
+            task_id = sample["task_id"]
+            r = results[task_id].pop(0)
+            sample["result"] = r[1]["result"]
+            sample["passed"] = r[1]["passed"]
+            yield sample
+
+    logger.info(f"Writing results to {result_path}...")
+    write_jsonl(result_path, tqdm.tqdm(combine_results(), total=n_samples))
+    _write_evaluate_log(pass_at_k, result_path, test_case_path, problem_path)
+
+    return {"pass_at_k": pass_at_k, "result_path": result_path}
+
+
+def run_evaluate_text2sql(state: Dict[str, Any], writer) -> Dict[str, Any]:
+    """评测 text2sql 样本，返回 pass@k 和 result_path。"""
+    state_task_id = state.get("task_id")
+    judger_state = state.get("judger", {})
+    output_dir = Path(state.get("output_dir"))
+    problem_path = judger_state["eval_problem_path"]
+    problem_file_name = Path(problem_path).stem
+    test_case_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_sample.jsonl"
+    )
+    result_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_result.jsonl"
+    )
+    case_num = judger_state.get("eval_case_num", 10)
+    task_type = judger_state["eval_task_type"]
+
+    k = list(map(int, K.split(",")))
+    problems = read_problems(problem_path)
+    total_samples = len(problems) * case_num
+
+    with ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        futures = []
+        completion_id = Counter()
+        n_samples = 0
+        results = defaultdict(list)
+
+        logger.info("Reading samples...")
+        for sample in tqdm.tqdm(stream_jsonl(test_case_path)):
+            task_id = sample["task_id"]
+            db_file = sample["db_file"]
+            question = sample["question"]
+            ground_truth = sample["ground_truth"]
+            pred_sql = sample["completion"]
+            args = (
+                (task_id, db_file, question, ground_truth, pred_sql),
+                TIMEOUT,
+                completion_id[task_id],
+            )
+            futures.append(executor.submit(compare_sql_wrapper, *args))
+            completion_id[task_id] += 1
+            n_samples += 1
+            writer(StreamEvent(
+                current="judger",
+                progress=round(n_samples / total_samples, 1),
+                message=f"{task_type}任务样本提交进度",
+                data={"progress_detail": f"{n_samples}/{total_samples}"}))
+
+        assert len(completion_id) == len(problems), "Some problems are not attempted."
+
+        n_samples2 = 0
+        logger.info("Running test suites...")
+        for future in tqdm.tqdm(as_completed(futures), total=len(futures)):
+            result = future.result()
+            results[result["task_id"]].append((result["completion_id"], result))
+            n_samples2 += 1
+            writer(StreamEvent(
+                current="judger",
+                progress=round(n_samples2 / total_samples, 1),
+                message=f"{task_type}任务样本评测进度",
+                data={"progress_detail": f"{n_samples2}/{total_samples}"}))
+
+    pass_at_k = _calculate_pass_at_k(k, results)
+
+    def combine_results():
+        for sample in stream_jsonl(test_case_path):
+            task_id = sample["task_id"]
+            r = results[task_id].pop(0)
+            sample["result"] = r[1]["result"]
+            sample["passed"] = r[1]["passed"]
+            yield sample
+
+    logger.info(f"Writing results to {result_path}...")
+    write_jsonl(result_path, tqdm.tqdm(combine_results(), total=n_samples))
+    _write_evaluate_log(pass_at_k, result_path, test_case_path, problem_path)
+
+    return {"pass_at_k": pass_at_k, "result_path": result_path}

--- a/loopai/skills/Judger/utils/format.py
+++ b/loopai/skills/Judger/utils/format.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+"""Standalone data format conversion — no LangGraph dependency.
+
+Extracted from ``loopai.agents.Judger.utils.oj.format``,
+replaced ``get_stream_writer()`` with a passed-in ``writer`` parameter.
+"""
+
+import json
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from loopai.common.event_tool import StreamEvent
+from loopai.logger import get_logger
+
+logger = get_logger()
+
+
+def _extract_function_names(code_text: str) -> str:
+    pattern = r"def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\("
+    names = list(dict.fromkeys(re.findall(pattern, code_text, re.MULTILINE)))
+    return names[0] if names else ""
+
+
+def _extract_before_and_func_def(code_text: str) -> str:
+    pattern = r"^(.*?def\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\(.*?\)\s*:)"
+    m = re.search(pattern, code_text, re.DOTALL | re.MULTILINE)
+    return m.group(1).rstrip() if m else ""
+
+
+def _mbpp_format(line: dict) -> dict:
+    if not isinstance(line, dict):
+        return {}
+    line["canonical_solution"] = line["code"]
+    line["test_list"] = list(dict.fromkeys(line["test_list"] + line["challenge_test_list"]))
+    line["prompt"] = (
+        _extract_before_and_func_def(line["code"])
+        + '\n    """'
+        + line["text"]
+        + '\n    """'
+    )
+    line["entry_point"] = _extract_function_names(line["code"])
+    for k in ("challenge_test_list", "code", "text", "test_setup_code"):
+        line.pop(k, None)
+    return line
+
+
+def _human_eval_format(line: dict) -> dict:
+    if not isinstance(line, dict):
+        return {}
+    line["canonical_solution"] = line["prompt"] + line["canonical_solution"]
+    parts = line["test"].split("assert ")
+    result = [parts[0]] + [f"assert {p}" for p in parts[1:]]
+    cleaned = [item.rstrip(" \n\r") for item in result]
+    filtered = [
+        ln.replace("candidate", line["entry_point"])
+        for ln in cleaned
+        if ln.startswith("assert ")
+    ]
+    filtered = [ln for ln in filtered if ln.strip().startswith("assert ")]
+    line["test_list"] = filtered
+    del line["test"]
+    return line
+
+
+def _preprocess_json_file(
+    input_path: str,
+    output_path: str,
+    line_processor: Optional[Callable[[dict], Optional[dict]]],
+    writer,
+) -> None:
+    use_temp_file = input_path == output_path
+    temp_file = None
+    total_lines = 0
+    success_lines = 0
+    error_lines = 0
+    filtered_lines = 0
+    cnt_lines = 0
+
+    try:
+        with open(input_path, "r", encoding="utf-8") as f:
+            total_lines = sum(1 for _ in f)
+
+        if use_temp_file:
+            temp_dir = os.path.dirname(os.path.abspath(input_path))
+            temp_file = tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", dir=temp_dir, delete=False
+            )
+            outfile = temp_file
+        else:
+            outfile = open(output_path, "w", encoding="utf-8")
+
+        with open(input_path, "r", encoding="utf-8") as infile, outfile:
+            for line in infile:
+                cnt_lines += 1
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    if not isinstance(data, dict):
+                        error_lines += 1
+                        continue
+                except json.JSONDecodeError:
+                    error_lines += 1
+                    continue
+
+                processed = line_processor(data) if line_processor else data
+                if processed is None:
+                    filtered_lines += 1
+                else:
+                    json.dump(processed, outfile, ensure_ascii=False)
+                    outfile.write("\n")
+                    success_lines += 1
+
+                writer(StreamEvent(
+                    current="judger",
+                    progress=round(cnt_lines / total_lines, 1),
+                    message="任务数据格式化中",
+                    data={"success": success_lines, "filtered": filtered_lines,
+                          "error": error_lines, "progress": f"{cnt_lines}/{total_lines}"}))
+
+        if use_temp_file and temp_file:
+            if os.path.exists(output_path):
+                os.remove(output_path)
+            shutil.move(temp_file.name, output_path)
+
+        logger.info(f"预处理完成 total={total_lines} success={success_lines} "
+                    f"error={error_lines} filtered={filtered_lines} -> {output_path}")
+
+    except FileNotFoundError:
+        logger.error(f"文件不存在: {input_path}")
+        writer(StreamEvent(
+            current="judger", progress=1.0, message="任务数据格式化出错",
+            data={"msg": f"文件不存在: {input_path}"}))
+    except Exception as e:
+        if use_temp_file and temp_file and os.path.exists(temp_file.name):
+            os.remove(temp_file.name)
+        logger.error(f"格式化意外错误: {e}")
+        writer(StreamEvent(
+            current="judger", progress=1.0, message="任务数据格式化出错",
+            data={"msg": str(e)}))
+    finally:
+        if temp_file:
+            temp_file.close()
+
+
+def run_format_data(state: Dict[str, Any], writer):
+    """数据格式转换入口，进度事件通过 ``writer`` 发送。"""
+    judger_state = state.get("judger", {})
+    method = judger_state.get("eval_format_type") or "human-eval"
+    state_task_id = state.get("task_id")
+    problem_path = judger_state["eval_problem_path"]
+    output_dir = Path(state.get("output_dir", "."))
+    problem_file_name = Path(problem_path).stem
+    target_format_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_format.jsonl"
+    )
+
+    formatter = {"human-eval": _human_eval_format, "mbpp": _mbpp_format}.get(
+        method, _human_eval_format
+    )
+    _preprocess_json_file(problem_path, target_format_path, formatter, writer)
+    state["judger"]["eval_problem_path"] = target_format_path

--- a/loopai/skills/Judger/utils/generate.py
+++ b/loopai/skills/Judger/utils/generate.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+"""Standalone code/text2sql sample generation — no LangGraph dependency.
+
+Extracted from ``loopai.agents.Judger.utils.oj.generate``,
+replaced ``get_stream_writer()`` with a passed-in ``writer`` parameter.
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from tqdm import tqdm
+from langchain_openai import ChatOpenAI
+
+from loopai.agents.Judger.utils.oj.data import read_problems, write_jsonl
+from loopai.common.event_tool import StreamEvent
+from loopai.logger import get_logger
+
+logger = get_logger()
+
+
+def _init_model(model_path: str, base_url: str, api_key: str,
+                temperature: float = 0, top_p: float = 0.95):
+    return ChatOpenAI(
+        model=model_path,
+        api_key=api_key,
+        base_url=base_url,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=16384,
+    )
+
+
+def run_generate_code(state: Dict[str, Any], writer) -> str:
+    """生成代码样本，进度事件通过 ``writer`` 发送。"""
+    state_task_id = state.get("task_id")
+    judger_state = state.get("judger", {})
+
+    model = _init_model(
+        model_path=judger_state["eval_model_path"],
+        base_url=judger_state["eval_base_url"],
+        api_key=judger_state.get("eval_api_key", "EMPTY"),
+        temperature=judger_state["eval_temperature"],
+        top_p=judger_state["eval_top_p"],
+    )
+    logger.info(f"模型路径:-> base_url: {judger_state['eval_base_url']}")
+
+    output_dir = Path(state.get("output_dir"))
+    problem_path = judger_state["eval_problem_path"]
+    problem_file_name = Path(problem_path).stem
+    test_case_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_sample.jsonl"
+    )
+
+    batch_size = judger_state["eval_batch_size"]
+    num_samples_per_task = judger_state["eval_case_num"]
+    task_type = judger_state["eval_task_type"]
+
+    problems = read_problems(problem_path)
+    all_task_ids = list(problems.keys())
+    total_tasks = len(all_task_ids)
+    total_samples = total_tasks * num_samples_per_task
+
+    writer(StreamEvent(
+        current="judger", progress=0.0,
+        message=f"{task_type}任务样本合成开始",
+        data={"total_tasks": total_tasks, "num_samples_per_task": num_samples_per_task,
+              "total_samples": total_samples}))
+
+    logger.info(f"===== 开始生成样本 =====")
+    logger.info(f"任务总数：{total_tasks}  每个任务样本数：{num_samples_per_task}  总样本数：{total_samples}")
+
+    samples = []
+    cnt = 0
+    with tqdm(total=total_samples, desc="生成进度") as pbar:
+        for case_id in range(0, total_samples, batch_size):
+            prompts = []
+            batch_task_id_list = []
+            for case_i in range(case_id, min(case_id + batch_size, total_samples), 1):
+                prompts.append(
+                    problems[all_task_ids[case_i // num_samples_per_task]]["prompt"]
+                )
+                batch_task_id_list.append(
+                    all_task_ids[case_i // num_samples_per_task]
+                )
+            responses = model.batch(prompts)
+            for task_id, response in zip(batch_task_id_list, responses):
+                samples.append({"task_id": task_id, "completion": response.content})
+                cnt += 1
+                pbar.update(1)
+            writer(StreamEvent(
+                current="judger",
+                progress=round(cnt / total_samples, 1),
+                message=f"{task_type}任务样本合成进度",
+                data={"progress_detail": f"{cnt}/{total_samples}"}))
+
+    write_jsonl(test_case_path, samples)
+    logger.info(f"===== 生成完成 ===== 样本数：{len(samples)}  路径：{test_case_path}")
+
+    writer(StreamEvent(
+        current="judger", progress=1.0, message=f"{task_type}任务样本合成完成",
+        data={"sample_num": len(samples), "sample_save_path": test_case_path}))
+    return test_case_path
+
+
+def run_generate_text2sql(state: Dict[str, Any], writer) -> str:
+    """生成 text2sql 样本，进度事件通过 ``writer`` 发送。"""
+    judger_state = state.get("judger", {})
+    state_task_id = state.get("task_id")
+
+    model = _init_model(
+        model_path=judger_state["eval_model_path"],
+        base_url=judger_state["eval_base_url"],
+        api_key="EMPTY",
+        temperature=judger_state["eval_temperature"],
+        top_p=judger_state["eval_top_p"],
+    )
+
+    output_dir = Path(state.get("output_dir"))
+    problem_path = judger_state["eval_problem_path"]
+    problem_file_name = Path(problem_path).stem
+    test_case_path = str(
+        output_dir / str(state_task_id) / "judger" / f"{problem_file_name}_sample.jsonl"
+    )
+
+    task_type = judger_state["eval_task_type"]
+    num_samples_per_task = judger_state["eval_case_num"]
+    batch_size = judger_state["eval_batch_size"]
+    text2sql_dir = Path(judger_state["eval_text2sql_dir"])
+
+    problems = read_problems(problem_path)
+    all_task_ids = list(problems.keys())
+    total_tasks = len(all_task_ids)
+    total_samples = total_tasks * num_samples_per_task
+
+    writer(StreamEvent(
+        current="judger", progress=0.0,
+        message=f"{task_type}任务样本合成开始",
+        data={"total_tasks": total_tasks, "num_samples_per_task": num_samples_per_task,
+              "total_samples": total_samples}))
+
+    logger.info(f"===== 开始生成样本 =====")
+    logger.info(f"任务总数：{total_tasks}  每个任务样本数：{num_samples_per_task}  总样本数：{total_samples}")
+
+    samples = []
+    cnt = 0
+    with tqdm(total=total_samples, desc="生成进度") as pbar:
+        for case_id in range(0, total_samples, batch_size):
+            prompts = []
+            batch_task_id_list = []
+            for case_i in range(case_id, min(case_id + batch_size, total_samples), 1):
+                prompts.append(
+                    problems[all_task_ids[case_i // num_samples_per_task]]["prompt"]
+                )
+                batch_task_id_list.append(
+                    all_task_ids[case_i // num_samples_per_task]
+                )
+            responses = model.batch(prompts)
+            for task_id, response in zip(batch_task_id_list, responses):
+                samples.append({
+                    "task_id": task_id,
+                    "completion": response.content,
+                    "db_file": str(text2sql_dir / problems[task_id]["db_id"]
+                                   / f"{problems[task_id]['db_id']}.sqlite"),
+                    "question": problems[task_id]["question"],
+                    "ground_truth": problems[task_id]["ground_truth"],
+                })
+                cnt += 1
+                pbar.update(1)
+            writer(StreamEvent(
+                current="judger",
+                progress=round(cnt / total_samples, 1),
+                message=f"{task_type}任务样本合成进度",
+                data={"progress_detail": f"{cnt}/{total_samples}"}))
+
+    write_jsonl(test_case_path, samples)
+    logger.info(f"===== 生成完成 ===== 样本数：{len(samples)}  路径：{test_case_path}")
+
+    writer(StreamEvent(
+        current="judger", progress=1.0, message=f"{task_type}任务样本合成完成",
+        data={"sample_num": len(samples), "sample_save_path": test_case_path}))
+    return test_case_path

--- a/skills/Judger/SKILL.md
+++ b/skills/Judger/SKILL.md
@@ -1,0 +1,206 @@
+# Judger Skill
+
+## Purpose
+Judger Skill is the Codex/Agent-facing capability for running LoopAI Judger independently. It evaluates model outputs (code generation, text-to-SQL, general text) and produces pass@k scores, execution results, and evaluation reports.
+
+## Python Implementation
+The Python skill layer lives in:
+
+`loopai/skills/Judger`
+
+Core Judger business logic remains in:
+
+`loopai/agents/Judger`
+
+Do not move or rewrite `generate.py`, `evaluate.py`, `execution.py`, or `eval_general_text_node.py` for normal skill usage. The skill layer is a standalone pipeline wrapper.
+
+## Runtime Entry
+```python
+from loopai.skills.Judger import run
+
+result = run(
+    state=state,
+    resume=False,
+    from_step=None,
+)
+```
+
+Direct runner:
+
+```python
+from loopai.skills.Judger.runner import run_judger_pipeline
+```
+
+Legacy import (LangGraph-based, via Starter) remains valid:
+
+```python
+from loopai.agents import JudgerAgent
+```
+
+## CLI
+```bash
+python examples/scripts/run_judger_standalone.py \
+    --config-path /tmp/judger_config.json \
+    --print-result
+```
+
+Supported options:
+
+- `--config-path` — JSON config file with judger fields
+- `--resume` — resume from last checkpoint
+- `--from-step` — force start from a specific step
+- `--checkpoint-path` — sqlite checkpoint file path
+- `--task-id` — override task id
+- `--output-dir` — override output directory
+- `--print-result` — print final result paths
+- `--list-steps` — print available pipeline steps
+
+## Pipeline Steps
+
+### code / text2sql pipeline
+```
+validate -> kill_vllm -> start_vllm -> format_data -> generate -> evaluate -> kill_vllm_cleanup -> finish
+```
+
+### general_text pipeline
+```
+validate -> eval_general_text -> finish
+```
+
+Step descriptions:
+
+| Step | Description |
+|------|-------------|
+| `validate` | Check required fields, file existence, JSONL field structure |
+| `kill_vllm` | Kill any existing local vLLM process on default port 8911 |
+| `start_vllm` | Start local vLLM with configured model_path, tensor_parallel_size, gpu_memory_utilization |
+| `format_data` | Optional data format conversion (human-eval, mbpp) |
+| `generate` | Generate code/text2sql samples via vLLM batch inference |
+| `evaluate` | Evaluate generated samples, produce pass@k results |
+| `kill_vllm_cleanup` | Kill local vLLM after evaluation |
+| `eval_general_text` | Run One-Eval DataFlowEvalTool for general text evaluation |
+| `finish` | Mark pipeline complete |
+
+## Environment Variables
+Runtime configuration should come from environment/system runtime where possible:
+
+- `JUDGER_MODEL_PATH` — model path for vLLM
+- `JUDGER_TASK_TYPE` — evaluation task type (code / text2sql / general_text)
+- `JUDGER_TEMPERATURE` — model temperature (default: 0)
+- `JUDGER_TOP_P` — model top_p (default: 0.95)
+- `JUDGER_PROBLEM_PATH` — path to evaluation problem JSONL file
+- `JUDGER_BATCH_SIZE` — batch size for sample generation (default: 10)
+- `JUDGER_CASE_NUM` — number of samples per problem (default: 10)
+- `JUDGER_FORMAT_TYPE` — optional data format type (human-eval, mbpp)
+- `JUDGER_TEXT2SQL_DIR` — database directory for text2sql tasks
+- `JUDGER_TENSOR_PARALLEL_SIZE` — vLLM tensor parallel size (default: 2)
+- `JUDGER_GPU_MEMORY_UTILIZATION` — vLLM GPU memory utilization (default: 0.9)
+- `CUDA_VISIBLE_DEVICES` — GPU device ids
+- `JUDGER_BENCH_NAME` — bench name for general_text (default: general_text_eval)
+- `JUDGER_BENCH_DATAFLOW_EVAL_TYPE` — One-Eval eval type
+- `JUDGER_CHECKPOINT_PATH` — sqlite checkpoint path
+- `TASK_ID` — task id
+- `OUTPUT_DIR` — output directory
+
+## Priority
+General runtime priority:
+
+`kwargs > env > state["judger"] > schema defaults`
+
+Example: `JUDGER_TASK_TYPE` env var overrides `state["judger"]["eval_task_type"]`, but a `judger_task_type="code"` kwarg takes priority over both.
+
+## vLLM Management
+Judger skill **only supports local vLLM startup**. Remote API (`eval_base_url`) is not supported in standalone mode.
+
+The pipeline automatically:
+1. Kills any existing vLLM on port 8911
+2. Starts vLLM with the configured model and GPU settings
+3. Kills vLLM after evaluation completes (for code/text2sql) or leaves it for the One-Eval tool to manage (for general_text)
+
+## Checkpoint And Resume
+Standalone Judger uses a function-level pipeline with sqlite checkpoints.
+
+The runner stores:
+- `state["current"]`
+- `state["last_completed"]`
+
+`--resume` continues from the checkpoint step and does not rerun completed steps. `--from-step` forces a specific Judger step.
+
+## Supported Task Types
+
+### code
+Generates code samples from prompts, executes against test suites, computes pass@k scores.
+Required JSONL fields: `task_id`, `prompt`, `entry_point`, `canonical_solution`, `test_list`
+Optional format types: `human-eval`, `mbpp`
+
+### text2sql
+Generates SQL queries, executes against SQLite databases, compares results.
+Required JSONL fields: `task_id`, `prompt`, `db_id`, `question`, `ground_truth`
+Additional config: `eval_text2sql_dir`
+
+### general_text
+Runs One-Eval DataFlowEvalTool in a subprocess for configurable evaluation types.
+Required config: `bench_dataflow_eval_type`
+Supported eval types: `key1_text_score`, `key2_qa`, `key2_q_ma`, `key3_q_choices_a`, `key3_q_choices_as`, `key3_q_a_rejected`
+
+## Success Response
+Return the Judger final state/result directly. Key output fields:
+
+```json
+{
+  "ok": true,
+  "status": "completed",
+  "message": "Judger pipeline completed.",
+  "data": {
+    "task_type": "code",
+    "output_result_path": "/path/to/xxx_result.jsonl",
+    "output_case_path": "/path/to/xxx_sample.jsonl",
+    "output_problem_path": "/path/to/xxx_format.jsonl"
+  },
+  "error": null
+}
+```
+
+For general_text tasks, `data` also includes `bench` with eval stats.
+
+## Error Response
+Validation failures and runtime errors:
+
+```json
+{
+  "ok": false,
+  "status": "failed",
+  "message": "Judger pipeline failed.",
+  "data": null,
+  "error": {
+    "type": "ValueError",
+    "code": "JUDGER_ERROR",
+    "detail": "Missing required fields: ...",
+    "traceback": "...",
+    "recoverable": true
+  }
+}
+```
+
+## Stream Runtime
+Judger standalone must not require LangGraph runtime. Stream writer calls use a safe fallback: outside LangGraph they emit nothing and continue running.
+
+## Config Via Configer
+Judger state config fields can be read/modified via the Configer skill:
+
+```python
+from loopai.skills.Configer import (
+    get_configer_state_schema,
+    get_configer_state_config,
+    update_configer_state_config,
+)
+
+# View judger schema
+schema = get_configer_state_schema(section_name="judger")
+
+# View current judger config
+config = get_configer_state_config(section_name="judger")
+
+# Update judger config
+update_configer_state_config("judger", {"eval_task_type": "code"})
+```

--- a/skills/Judger/SKILL.md
+++ b/skills/Judger/SKILL.md
@@ -1,192 +1,449 @@
 # Judger Skill
 
 ## Purpose
-Judger Skill is the Codex/Agent-facing capability for running LoopAI Judger independently. It evaluates model outputs (code generation, text-to-SQL, general text) and produces pass@k scores, execution results, and evaluation reports.
+
+Judger Skill 用于在无 LangGraph（独立模式）下运行 LoopAI 评测流水线。支持三种任务类型：
+
+- **code** — 代码生成评测（human-eval / mbpp 格式），计算 pass@k
+- **text2sql** — SQL 生成评测，在 SQLite 数据库上执行校验
+- **general_text** — 通用文本评测（One-Eval DataFlowEvalTool）
+
+所有评测结果写入文件系统，进度事件持久化到 pickle，state 持久化到 SQLite checkpoint。
+
+## When to Use
+
+当 Codex 或用户要执行以下操作时使用本 skill：
+
+- 评测模型生成的代码 / SQL / 文本
+- 计算 pass@k、accuracy 等指标
+- 从 starter.yaml 配置启动评测流水线
+- 断点续跑中断的评测任务
+- 查看评测进度事件
+
+不要用它处理：
+
+- 训练、数据爬取、数据构造（走对应的 Agent/Skill）
+- 全局 `system` 配置修改（走 Configer 或直接改 starter.yaml）
 
 ## Python Implementation
-The Python skill layer lives in:
 
-`loopai/skills/Judger`
+```
+loopai/skills/Judger/          ← Skill 层（独立模式，无 LangGraph）
+├── __init__.py                # run() / load_events()
+├── runner.py                  # 流水线主逻辑
+├── runtime_config.py          # 配置解析（kwargs > env > YAML > defaults）
+└── utils/
+    ├── eval_general_text.py   # general_text 评测
+    ├── generate.py            # code/text2sql 样本生成
+    ├── evaluate.py            # code/text2sql 评测
+    └── format.py              # 数据格式转换
 
-Core Judger business logic remains in:
+loopai/agents/Judger/          ← Agent 层（LangGraph，供 Starter 用）
+    └── ...                     # 保持不变
+```
 
-`loopai/agents/Judger`
+## Quick Start
 
-Do not move or rewrite `generate.py`, `evaluate.py`, `execution.py`, or `eval_general_text_node.py` for normal skill usage. The skill layer is a standalone pipeline wrapper.
+### 方式 1: CLI（推荐）
 
-## Runtime Entry
+```bash
+# general_text 评测
+python examples/scripts/run_judger_standalone.py \
+    --config-path starter.yaml \
+    --task-id my_eval_001 \
+    --print-result
+
+# code 评测（human-eval 格式）
+python examples/scripts/run_judger_standalone.py \
+    --config-path starter.yaml \
+    --task-id my_code_eval \
+    --print-result
+
+# 查看流水线步骤
+python examples/scripts/run_judger_standalone.py --list-steps
+
+# 断点续跑
+python examples/scripts/run_judger_standalone.py \
+    --task-id my_eval_001 \
+    --resume
+```
+
+### 方式 2: Python API
+
 ```python
 from loopai.skills.Judger import run
 
 result = run(
-    state=state,
-    resume=False,
-    from_step=None,
+    state={
+        "judger": {
+            "eval_model_path": "/data/models/Qwen2.5-7B-Instruct",
+            "eval_task_type": "general_text",
+            "eval_problem_path": "/data/problems/test.jsonl",
+            "bench_dataflow_eval_type": "key2_qa",
+        },
+        "task_id": "my_task",
+        "output_dir": "./outputs",
+    },
+    thread_id="my_task",
 )
+print(result["judger"]["output_result_path"])
 ```
 
-Direct runner:
+### 方式 3: Codex 子进程
 
-```python
-from loopai.skills.Judger.runner import run_judger_pipeline
-```
-
-Legacy import (LangGraph-based, via Starter) remains valid:
-
-```python
-from loopai.agents import JudgerAgent
-```
-
-## CLI
 ```bash
-python examples/scripts/run_judger_standalone.py \
-    --config-path /tmp/judger_config.json \
-    --print-result
+timeout 600 python3 -u <<'PY'
+import json
+from loopai.skills.Judger import run
+result = run(
+    state={"judger": {...}, "task_id": "task_001"},
+    thread_id="task_001",
+)
+print(json.dumps({"ok": True, "data": result["judger"]}, ensure_ascii=False))
+PY
 ```
 
-Supported options:
+## Configuration
 
-- `--config-path` — JSON config file with judger fields
-- `--resume` — resume from last checkpoint
-- `--from-step` — force start from a specific step
-- `--checkpoint-path` — sqlite checkpoint file path
-- `--task-id` — override task id
-- `--output-dir` — override output directory
-- `--print-result` — print final result paths
-- `--list-steps` — print available pipeline steps
+### starter.yaml 结构
+
+```yaml
+default_states:
+  task_id: "my_task"          # 必填，通过 --task-id 覆盖
+  output_dir: "./outputs"     # 输出根目录
+
+  judger:
+    # --- 必填字段 ---
+    eval_model_path: "/data/models/Qwen2.5-7B-Instruct"  # 模型路径
+    eval_task_type: "general_text"     # code / text2sql / general_text
+    eval_problem_path: "/data/test.jsonl"  # 问题文件路径
+
+    # --- 模型参数 ---
+    eval_temperature: 0               # 温度（默认 0）
+    eval_top_p: 0.95                  # top_p（默认 0.95）
+
+    # --- 样本参数 ---
+    eval_batch_size: 10               # 批处理大小（默认 10）
+    eval_case_num: 10                 # 每问题样本数（默认 10）
+
+    # --- vLLM 参数 ---
+    eval_vllm_tensor_parallel_size: 1 # 张量并行数（默认 2）
+    eval_vllm_gpu_memory_utilization: 0.9  # GPU 显存利用率
+    cuda_visible_devices: "5"         # 可见 GPU
+
+    # --- general_text 专用 ---
+    bench_name: "gsm8k"
+    bench_dataflow_eval_type: "key2_qa"  # 评测类型，见下表
+
+  # YAML 中可用短键名（兼容旧配置）：
+  #   tensor_parallel_size → eval_vllm_tensor_parallel_size
+```
+
+### general_text 评测类型
+
+| `bench_dataflow_eval_type` | 说明 |
+|---|---|
+| `key1_text_score` | 文本评分 |
+| `key2_qa` | 问答评测 |
+| `key2_q_ma` | 多答案评测 |
+| `key3_q_choices_a` | 选择题评测 |
+| `key3_q_choices_as` | 多选评测 |
+| `key3_q_a_rejected` | 对比评测 |
+
+### 配置优先级
+
+```
+CLI --task-id / --output-dir > 环境变量 > YAML default_states.judger > schema 默认值
+```
+
+## CLI Reference
+
+```
+python examples/scripts/run_judger_standalone.py [OPTIONS]
+
+Options:
+  --config-path PATH    配置文件路径（starter.yaml 或 JSON）
+  --task-id ID          任务 ID（必填）
+  --output-dir DIR      输出目录（默认 ./outputs）
+  --resume              从上次 checkpoint 恢复
+  --from-step STEP      从指定步骤开始执行
+  --checkpoint-path PATH SQLite checkpoint 路径
+  --print-result        打印结果摘要
+  --print-events        打印事件列表
+  --list-steps          列出流水线步骤
+```
+
+**`--task-id` 是必填的**，不传会报 `CONFIG_ERROR`。可通过 `TASK_ID` 环境变量替代。
+
+**`--config-path` 和 `--resume` 互斥**：resume 时 state 从 checkpoint 加载（不含 config-path 也不会报错），但可通过环境变量覆盖部分字段。
+
+## Python API
+
+```python
+from loopai.skills.Judger import run, load_events
+from loopai.skills.Judger.runner import (
+    run_judger_pipeline,
+    save_judger_checkpoint,
+    load_judger_checkpoint,
+)
+
+# 运行流水线
+result = run(
+    state=None,             # dict with state["judger"] fields
+    thread_id="task_001",   # 必填，= task_id
+    resume=False,           # True = 从 checkpoint 恢复
+    from_step=None,         # 强制起始步骤名
+    checkpoint_path=None,   # 自定义 checkpoint 路径
+    **kwargs,               # 运行时覆盖（优先于 state）
+)
+
+# 读取事件
+events = load_events(task_id="task_001", output_dir="./outputs")
+
+# 读取 checkpoint
+state = load_judger_checkpoint("task_001", "outputs/judger_checkpoints.sqlite")
+```
 
 ## Pipeline Steps
 
 ### code / text2sql pipeline
+
 ```
-validate -> kill_vllm -> start_vllm -> format_data -> generate -> evaluate -> kill_vllm_cleanup -> finish
+validate → kill_vllm → start_vllm → format_data → generate → evaluate → kill_vllm_cleanup → finish
 ```
 
 ### general_text pipeline
+
 ```
-validate -> eval_general_text -> finish
+validate → eval_general_text → finish
 ```
 
-Step descriptions:
-
-| Step | Description |
-|------|-------------|
-| `validate` | Check required fields, file existence, JSONL field structure |
-| `kill_vllm` | Kill any existing local vLLM process on default port 8911 |
-| `start_vllm` | Start local vLLM with configured model_path, tensor_parallel_size, gpu_memory_utilization |
-| `format_data` | Optional data format conversion (human-eval, mbpp) |
-| `generate` | Generate code/text2sql samples via vLLM batch inference |
-| `evaluate` | Evaluate generated samples, produce pass@k results |
-| `kill_vllm_cleanup` | Kill local vLLM after evaluation |
-| `eval_general_text` | Run One-Eval DataFlowEvalTool for general text evaluation |
-| `finish` | Mark pipeline complete |
+| Step | 功能 |
+|---|---|
+| `validate` | 校验必填字段、文件存在性、JSONL 字段结构 |
+| `kill_vllm` | 关闭端口 8911 上的 vLLM 进程 |
+| `start_vllm` | 启动本地 vLLM 服务 |
+| `format_data` | 数据格式转换（human-eval / mbpp），可选 |
+| `generate` | vLLM 批量生成 code/text2sql 样本 |
+| `evaluate` | 执行代码/执行 SQL，计算 pass@k |
+| `kill_vllm_cleanup` | 评测后关闭 vLLM |
+| `eval_general_text` | One-Eval DataFlowEvalTool 子进程评测 |
+| `finish` | 流水线完成 |
 
 ## Environment Variables
-Runtime configuration should come from environment/system runtime where possible:
 
-- `JUDGER_MODEL_PATH` — model path for vLLM
-- `JUDGER_TASK_TYPE` — evaluation task type (code / text2sql / general_text)
-- `JUDGER_TEMPERATURE` — model temperature (default: 0)
-- `JUDGER_TOP_P` — model top_p (default: 0.95)
-- `JUDGER_PROBLEM_PATH` — path to evaluation problem JSONL file
-- `JUDGER_BATCH_SIZE` — batch size for sample generation (default: 10)
-- `JUDGER_CASE_NUM` — number of samples per problem (default: 10)
-- `JUDGER_FORMAT_TYPE` — optional data format type (human-eval, mbpp)
-- `JUDGER_TEXT2SQL_DIR` — database directory for text2sql tasks
-- `JUDGER_TENSOR_PARALLEL_SIZE` — vLLM tensor parallel size (default: 2)
-- `JUDGER_GPU_MEMORY_UTILIZATION` — vLLM GPU memory utilization (default: 0.9)
-- `CUDA_VISIBLE_DEVICES` — GPU device ids
-- `JUDGER_BENCH_NAME` — bench name for general_text (default: general_text_eval)
-- `JUDGER_BENCH_DATAFLOW_EVAL_TYPE` — One-Eval eval type
-- `JUDGER_CHECKPOINT_PATH` — sqlite checkpoint path
-- `TASK_ID` — task id
-- `OUTPUT_DIR` — output directory
+| 变量 | 对应字段 | 默认值 |
+|---|---|---|
+| `TASK_ID` | `task_id` | 必填，无默认 |
+| `OUTPUT_DIR` | `output_dir` | `./outputs` |
+| `JUDGER_MODEL_PATH` | `eval_model_path` | 必填 |
+| `JUDGER_TASK_TYPE` | `eval_task_type` | `code` |
+| `JUDGER_TEMPERATURE` | `eval_temperature` | `0` |
+| `JUDGER_TOP_P` | `eval_top_p` | `0.95` |
+| `JUDGER_PROBLEM_PATH` | `eval_problem_path` | 必填 |
+| `JUDGER_BATCH_SIZE` | `eval_batch_size` | `10` |
+| `JUDGER_CASE_NUM` | `eval_case_num` | `10` |
+| `JUDGER_FORMAT_TYPE` | `eval_format_type` | 可选 |
+| `JUDGER_TEXT2SQL_DIR` | `eval_text2sql_dir` | text2sql 必填 |
+| `JUDGER_TENSOR_PARALLEL_SIZE` | `eval_vllm_tensor_parallel_size` | `2` |
+| `JUDGER_GPU_MEMORY_UTILIZATION` | `eval_vllm_gpu_memory_utilization` | `0.9` |
+| `CUDA_VISIBLE_DEVICES` | `cuda_visible_devices` | `0` |
+| `JUDGER_BENCH_NAME` | `bench_name` | `general_text_eval` |
+| `JUDGER_BENCH_DATAFLOW_EVAL_TYPE` | `bench_dataflow_eval_type` | 空（general_text 必填） |
+| `JUDGER_CHECKPOINT_PATH` | checkpoint 路径 | `outputs/judger_checkpoints.sqlite` |
 
-## Priority
-General runtime priority:
+## Output & Artifacts
 
-`kwargs > env > state["judger"] > schema defaults`
+```
+outputs/<task_id>/
+├── judger/
+│   ├── <name>_format.jsonl           # 格式化后的问题文件
+│   ├── <name>_sample.jsonl           # 生成的样本
+│   ├── <name>_result.jsonl           # 评测结果
+│   ├── log.txt                       # 评测日志
+│   ├── text_eval_summary_*.json      # general_text 摘要
+│   ├── general_text_dataset_cache_*.jsonl  # 缓存
+│   └── gsm8k_*_steps/               # One-Eval 中间产物
+├── judger.pkl                        # 事件 pickle（load_events 读取）
+└── judger_checkpoints.sqlite         # state checkpoint（全局共享）
+```
 
-Example: `JUDGER_TASK_TYPE` env var overrides `state["judger"]["eval_task_type"]`, but a `judger_task_type="code"` kwarg takes priority over both.
+- **stdout** — 最终结果 JSON payload（Codex 消费）
+- **stderr** — `--print-result` / `--print-events` 的输出
+- **judger.pkl** — 所有进度事件，`load_events(task_id)` 读取
+- **checkpoint** — 每步前后自动保存，`load_judger_checkpoint(task_id)` 读取
+
+## Checkpoint & Resume
+
+### 工作原理
+
+每一步执行前后自动保存 state 到 SQLite：
+
+```
+outputs/judger_checkpoints.sqlite
+  ┌──────────────┬──────────────────────┬──────────────────────┐
+  │ thread_id    │ state_json           │ updated_at           │
+  ├──────────────┼──────────────────────┼──────────────────────┤
+  │ my_task      │ {"last_completed":   │ 2026-06-18T12:00:00Z │
+  │              │  "generate", ...}    │                      │
+  └──────────────┴──────────────────────┴──────────────────────┘
+```
+
+### 断点续跑
+
+```bash
+# 从上次中断处继续（跳过已完成步骤）
+python examples/scripts/run_judger_standalone.py --task-id my_task --resume
+
+# 从指定步骤强制执行（跳过之前所有步骤）
+python examples/scripts/run_judger_standalone.py \
+    --task-id my_task --from-step evaluate
+
+# resume + 覆盖部分配置
+CUDA_VISIBLE_DEVICES=6 python examples/scripts/run_judger_standalone.py \
+    --task-id my_task --resume
+```
+
+**注意**：`--resume` 时 state 从 checkpoint 加载，不需要 `--config-path`。但可通过环境变量覆盖字段（如换 GPU、改温度）。
+
+### 查看 checkpoint
+
+```python
+from loopai.skills.Judger.runner import load_judger_checkpoint
+
+state = load_judger_checkpoint("my_task", "outputs/judger_checkpoints.sqlite")
+print(state["last_completed"])  # 最后完成的步骤
+print(state["judger"]["output_result_path"])
+```
+
+## Event System
+
+### 事件写入
+
+流水线运行时自动持久化到 `<output_dir>/<task_id>/judger.pkl`：
+
+```python
+from loopai.common.event_tool import get_event_writer, StreamEvent
+
+writer = get_event_writer(name="judger", context_id="task_001", log_file_path="./outputs")
+writer(StreamEvent(current="judger", progress=0.5, message="样本生成中"))
+```
+
+### 事件读取
+
+```python
+from loopai.skills.Judger import load_events
+
+events = load_events(task_id="my_task")
+for e in events:
+    print(f'[{e["time"]}] progress={e["progress"]} {e["message"]}')
+# [2026-06-18T12:00:00Z] progress=0.0 Judger pipeline started
+# [2026-06-18T12:00:01Z] progress=0.5 DataFlowEvalTool 子进程仍在运行
+# [2026-06-18T12:05:00Z] progress=1.0 流水线完成
+```
+
+## Error Handling
+
+所有错误通过 `loopai.common.exception.emit_error` 输出标准 JSON payload：
+
+| ErrorCode | 触发场景 |
+|---|---|
+| `CONFIG_ERROR` | 缺少必填字段、模型路径未配置 |
+| `INVALID_INPUT` | JSONL 字段不匹配、不支持的任务类型 |
+| `NOT_FOUND` | 问题文件不存在 |
+| `EXTERNAL_SERVICE_ERROR` | DataFlowEvalTool 子进程失败 |
+
+### 错误响应格式
+
+```json
+{
+    "ok": false,
+    "status": "failed",
+    "message": "Judger configuration is incomplete.",
+    "data": null,
+    "error": {
+        "type": "ValueError",
+        "code": "CONFIG_ERROR",
+        "detail": "Missing required fields: {\"missing_fields\": {\"judger\": [\"eval_model_path\"]}}",
+        "traceback": "...",
+        "recoverable": true,
+        "time": "2026-06-18T12:00:00Z"
+    }
+}
+```
+
+### 成功响应格式
+
+```json
+{
+    "ok": true,
+    "status": "completed",
+    "message": "Judger pipeline completed.",
+    "data": {
+        "task_type": "general_text",
+        "output_result_path": "/path/to/summary.json",
+        "output_case_path": "",
+        "output_problem_path": "/path/to/cache.jsonl",
+        "output_pred_path": "/path/to/step2.jsonl",
+        "bench": {
+            "bench_name": "gsm8k",
+            "eval_status": "success",
+            "meta": {"eval_result": {"accuracy": 0.94}}
+        }
+    },
+    "error": null
+}
+```
 
 ## vLLM Management
-Judger skill **only supports local vLLM startup**. Remote API (`eval_base_url`) is not supported in standalone mode.
 
-The pipeline automatically:
-1. Kills any existing vLLM on port 8911
-2. Starts vLLM with the configured model and GPU settings
-3. Kills vLLM after evaluation completes (for code/text2sql) or leaves it for the One-Eval tool to manage (for general_text)
+**仅支持本地 vLLM 启动。** 远程 API（`eval_base_url`）在独立模式下不支持。
 
-## Checkpoint And Resume
-Standalone Judger uses a function-level pipeline with sqlite checkpoints.
+流水线自动管理 vLLM 生命周期：
 
-The runner stores:
-- `state["current"]`
-- `state["last_completed"]`
+1. 关闭端口 8911 上已有的 vLLM 进程
+2. 使用配置的 model_path、tensor_parallel_size、gpu_memory_utilization 启动 vLLM
+3. code/text2sql 评测完成后自动关闭；general_text 由 One-Eval 自行管理
 
-`--resume` continues from the checkpoint step and does not rerun completed steps. `--from-step` forces a specific Judger step.
+## Codex Integration
 
-## Supported Task Types
+Codex 通过子进程调用 Python 函数，读取 stdout JSON：
 
-### code
-Generates code samples from prompts, executes against test suites, computes pass@k scores.
-Required JSONL fields: `task_id`, `prompt`, `entry_point`, `canonical_solution`, `test_list`
-Optional format types: `human-eval`, `mbpp`
+```bash
+timeout 600 python3 -u <<'PY'
+import json, sys
+from loopai.skills.Judger import run
 
-### text2sql
-Generates SQL queries, executes against SQLite databases, compares results.
-Required JSONL fields: `task_id`, `prompt`, `db_id`, `question`, `ground_truth`
-Additional config: `eval_text2sql_dir`
-
-### general_text
-Runs One-Eval DataFlowEvalTool in a subprocess for configurable evaluation types.
-Required config: `bench_dataflow_eval_type`
-Supported eval types: `key1_text_score`, `key2_qa`, `key2_q_ma`, `key3_q_choices_a`, `key3_q_choices_as`, `key3_q_a_rejected`
-
-## Success Response
-Return the Judger final state/result directly. Key output fields:
-
-```json
-{
-  "ok": true,
-  "status": "completed",
-  "message": "Judger pipeline completed.",
-  "data": {
-    "task_type": "code",
-    "output_result_path": "/path/to/xxx_result.jsonl",
-    "output_case_path": "/path/to/xxx_sample.jsonl",
-    "output_problem_path": "/path/to/xxx_format.jsonl"
-  },
-  "error": null
-}
+try:
+    result = run(
+        state={
+            "judger": {
+                "eval_model_path": "/data/models/Qwen2.5-7B-Instruct",
+                "eval_task_type": "general_text",
+                "eval_problem_path": "/data/test.jsonl",
+                "bench_dataflow_eval_type": "key2_qa",
+                "eval_batch_size": 4,
+                "cuda_visible_devices": "5",
+            },
+            "task_id": "codex_task_001",
+            "output_dir": "./outputs",
+        },
+        thread_id="codex_task_001",
+    )
+    print(json.dumps({"ok": True, "data": result["judger"]}, ensure_ascii=False))
+except Exception as e:
+    # 错误已通过 emit_error 输出到 stdout，直接退出即可
+    sys.exit(1)
+PY
 ```
 
-For general_text tasks, `data` also includes `bench` with eval stats.
-
-## Error Response
-Validation failures and runtime errors:
-
-```json
-{
-  "ok": false,
-  "status": "failed",
-  "message": "Judger pipeline failed.",
-  "data": null,
-  "error": {
-    "type": "ValueError",
-    "code": "JUDGER_ERROR",
-    "detail": "Missing required fields: ...",
-    "traceback": "...",
-    "recoverable": true
-  }
-}
-```
-
-## Stream Runtime
-Judger standalone must not require LangGraph runtime. Stream writer calls use a safe fallback: outside LangGraph they emit nothing and continue running.
+Codex 读到的 stdout 行：
+- 成功：`{"ok": true, "data": {"output_result_path": "...", "bench": {...}}}`
+- 失败：`{"ok": false, "error": {"code": "CONFIG_ERROR", "detail": "..."}}`
 
 ## Config Via Configer
-Judger state config fields can be read/modified via the Configer skill:
+
+Judger 配置字段可通过 Configer skill 读写：
 
 ```python
 from loopai.skills.Configer import (
@@ -195,12 +452,16 @@ from loopai.skills.Configer import (
     update_configer_state_config,
 )
 
-# View judger schema
+# 查看 schema（字段含义、允许值、默认值）
 schema = get_configer_state_schema(section_name="judger")
 
-# View current judger config
+# 读取当前实际配置
 config = get_configer_state_config(section_name="judger")
 
-# Update judger config
-update_configer_state_config("judger", {"eval_task_type": "code"})
+# 修改配置
+update_configer_state_config("judger", {
+    "eval_task_type": "general_text",
+    "eval_temperature": 0.2,
+})
 ```
+


### PR DESCRIPTION
done:

1. 构建新的juger agent , 可通过examples/scripts/run_judger_standalone.py 使用。运行时加入--help获取具体参数填写帮助
2. 注意事项：--resume 断点重启，starter.yaml里的配置优先级比环境变量更高，可以通过更改starter里的配置后，task_id为必填项，启动时可以从--task_id传入或者starter.yaml里面读取
3. 最终state写入sqlite，未指定checkpoint-path 时，在第一次保存checkpoint时建库建表
4. 错误上报使用emit_error ，会终止进程，可以通过--resume来重启,从数据库中恢复state
5. skills/Judger/SKILL.md
6. 三项评测任务都已跑通

todo:

-  web codex还没有调试过