### PR TITLE
feat(obtainer): benchmark 注册守卫 + 用户指定 L3 可出湖 + 出湖/导出 UI

### DIFF
--- a/api/app/controllers/obtainer.py
+++ b/api/app/controllers/obtainer.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from ..models.body import response_body
-from ..utils.obtainer.monitor import probe_embedding_health
+from ..utils.obtainer.monitor import _export_preview, probe_embedding_health
 from ..utils.obtainer.web_pipeline import build_web_pipeline_overview
 from loopai.skills.ObtainerCLI.monitor_state import read_monitor_state, start_background_rebuild
 from loopai.skills.ObtainerCLI.datamixer_adapter import warehouse_root
@@ -361,6 +361,22 @@ async def get_webagent_overview(
         if isinstance(monitor, dict) and live_summary.get("datasets") is not None:
             monitor.setdefault("summary", {})["datasets"] = int(live_summary["datasets"])
             monitor["summary"]["records"] = int(live_summary.get("records") or 0)
+        # Live-enrich cached export rows with manifest-backed descriptions so the
+        # task card can show recipe/records/buckets without waiting on a cache rebuild.
+        if isinstance(monitor, dict):
+            latest = monitor.setdefault("latest", {})
+            cached_exports = latest.get("exports")
+            if isinstance(cached_exports, list):
+                enriched = []
+                for row in cached_exports:
+                    if isinstance(row, dict):
+                        row = dict(row)
+                        if not row.get("description"):
+                            row["description"] = _export_preview(row).get("description")
+                        enriched.append(row)
+                    else:
+                        enriched.append(row)
+                latest["exports"] = enriched
     except Exception as exc:
         return response_body(code=400, status="error", message=str(exc))()
     return response_body(data=data)()
@@ -469,3 +485,132 @@ async def run_datamixer_cli(request: DataMixerCliRequest):
     except Exception as exc:
         return response_body(code=400, status="error", message=str(exc))()
     return response_body(data=result)()
+
+
+# ---------------------------------------------------------------------------
+# Export file serving: browser-side download + preview/description
+# ---------------------------------------------------------------------------
+from fastapi.responses import FileResponse
+
+
+def _resolve_export_file(uri: str | None) -> tuple[Path, Path | None]:
+    """Resolve an export output_uri to (target_file, manifest_file).
+
+    output_uri may point at a file (export-jsonl) or a directory containing
+    part-*.jsonl plus manifest.json (recipe_export). Only paths inside the
+    project repo are allowed.
+    """
+    if not uri:
+        raise ValueError("缺少导出路径 uri")
+    raw = Path(str(uri)).expanduser()
+    path = raw if raw.is_absolute() else (REPO_ROOT / raw)
+    path = path.resolve()
+    try:
+        common = Path(os.path.commonpath([str(path), str(REPO_ROOT.resolve())]))
+        if common != REPO_ROOT.resolve():
+            raise ValueError("导出路径超出允许范围")
+    except ValueError as exc:
+        raise ValueError("导出路径超出允许范围") from exc
+
+    if path.is_dir():
+        parts = sorted(path.glob("part-*.jsonl"))
+        if not parts:
+            parts = sorted(path.glob("*.jsonl"))
+        if not parts:
+            raise FileNotFoundError(f"目录中未找到导出文件: {path}")
+        manifest = path / "manifest.json"
+        return parts[0], manifest if manifest.exists() else None
+    if not path.exists():
+        raise FileNotFoundError(f"导出文件不存在: {path}")
+    manifest = path.parent / "manifest.json"
+    return path, manifest if manifest.exists() else None
+
+
+def _export_description(manifest: Path | None, *, file_path: Path, strategy: str = "") -> dict:
+    """Build a human-readable description from the export manifest / recipe."""
+    desc: dict[str, Any] = {
+        "file": file_path.name,
+        "size_bytes": file_path.stat().st_size if file_path.exists() else 0,
+        "strategy": strategy,
+    }
+    if not manifest or not manifest.exists():
+        return desc
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except Exception:
+        return desc
+    desc["export_id"] = data.get("export_id", "")
+    desc["recipe_name"] = data.get("recipe_name", "")
+    desc["snapshot_id"] = data.get("snapshot_id", "")
+    desc["format"] = data.get("format", "")
+    files = data.get("files") or []
+    desc["files"] = files
+    desc["records"] = sum(int(f.get("records") or 0) for f in files)
+    recipe = data.get("recipe") or {}
+    if isinstance(recipe, dict) and recipe.get("recipe"):
+        recipe = recipe["recipe"]
+    desc["total_samples"] = recipe.get("total_samples", 0)
+    desc["strategy"] = recipe.get("strategy", desc.get("strategy"))
+    buckets = recipe.get("buckets") or []
+    desc["buckets"] = [b.get("name", "") for b in buckets if isinstance(b, dict)]
+    return desc
+
+
+@router.get(
+    "/export/download",
+    operation_id="downloadObtainerExportFile",
+    summary="下载出湖/导出文件到浏览器",
+)
+async def download_export_file(uri: str, root: str | None = None):
+    try:
+        target, _ = _resolve_export_file(uri)
+    except Exception as exc:
+        return response_body(code=400, status="error", message=str(exc))()
+    return FileResponse(
+        str(target),
+        media_type="application/octet-stream",
+        filename=target.name,
+        headers={"Content-Disposition": f'attachment; filename="{target.name}"'},
+    )
+
+
+@router.get(
+    "/export/preview",
+    operation_id="previewObtainerExportFile",
+    summary="预览出湖/导出文件内容并返回描述",
+)
+async def preview_export_file(uri: str, limit: int = 20, root: str | None = None):
+    try:
+        limit = max(1, min(int(limit), 200))
+        target, manifest = _resolve_export_file(uri)
+        description = _export_description(manifest, file_path=target)
+        rows: list[dict[str, Any]] = []
+        with target.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+                if len(rows) >= limit:
+                    break
+        columns: list[str] = []
+        if rows:
+            seen: set[str] = set()
+            for row in rows:
+                for key in row.keys():
+                    if key not in seen:
+                        seen.add(key)
+                        columns.append(key)
+        return response_body(data={
+            "uri": uri,
+            "file": target.name,
+            "description": description,
+            "columns": columns,
+            "rows": rows,
+            "row_count": len(rows),
+        })()
+    except Exception as exc:
+        return response_body(code=400, status="error", message=str(exc))()

--- a/api/app/utils/obtainer/monitor.py
+++ b/api/app/utils/obtainer/monitor.py
@@ -108,7 +108,7 @@ def _quality_preview(row: dict) -> dict:
 
 
 def _export_preview(row: dict) -> dict:
-    return {
+    preview = {
         "export_id": row.get("export_id", ""),
         "strategy": row.get("strategy", ""),
         "requested_size": row.get("requested_size", 0),
@@ -117,6 +117,29 @@ def _export_preview(row: dict) -> dict:
         "format": row.get("format", ""),
         "created_at": row.get("created_at", ""),
     }
+    uri = row.get("output_uri") or ""
+    if uri:
+        uri_path = Path(str(uri)).expanduser()
+        manifest = uri_path / "manifest.json" if uri_path.is_dir() else uri_path.parent / "manifest.json"
+        if manifest.is_file():
+            try:
+                data = json.loads(manifest.read_text(encoding="utf-8"))
+                recipe = data.get("recipe") or {}
+                if isinstance(recipe, dict) and isinstance(recipe.get("recipe"), dict):
+                    recipe = recipe["recipe"]
+                files = data.get("files") or []
+                preview["description"] = {
+                    "recipe_name": data.get("recipe_name", ""),
+                    "records": int(sum(int(f.get("records") or 0) for f in files)),
+                    "total_samples": int(recipe.get("total_samples") or 0) if isinstance(recipe, dict) else 0,
+                    "strategy": recipe.get("strategy", "") if isinstance(recipe, dict) else "",
+                    "snapshot_id": data.get("snapshot_id", ""),
+                    "buckets": [b.get("name", "") for b in (recipe.get("buckets") or []) if isinstance(b, dict)]
+                    if isinstance(recipe, dict) else [],
+                }
+            except Exception:
+                pass
+    return preview
 
 
 def _count_by(rows: list[dict], field: str) -> dict[str, int]:

--- a/codex-runner/src/index.ts
+++ b/codex-runner/src/index.ts
@@ -1,9 +1,16 @@
+import fs from "node:fs";
 import { Codex, type ThreadEvent, type ThreadItem } from "@openai/codex-sdk";
 
 type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 const MAX_COMMAND_OUTPUT_CHARS = Number(process.env.CODEX_EVENT_MAX_OUTPUT_CHARS ?? "12000");
 
-const prompt = process.argv.slice(2).join(" ");
+let prompt = process.argv.slice(2).join(" ").trim();
+if (process.env.CODEX_PROMPT_FILE) {
+    // Prompt delivered via a temp file to avoid ARG_MAX / execve argument limits.
+    prompt = fs.readFileSync(process.env.CODEX_PROMPT_FILE, "utf8").trim();
+} else if ((!prompt || prompt === "-") && !process.stdin.isTTY) {
+    prompt = fs.readFileSync(0, "utf8").trim();
+}
 const timeoutMs = Number(process.env.CODEX_RUN_TIMEOUT_MS ?? "300000");
 const workspace = process.env.CODEX_WORKSPACE;
 const model = process.env.CODEX_MODEL ?? process.env.DEEPSEEK_MODEL;

--- a/docs/OBTAINERCLI_USAGE.md
+++ b/docs/OBTAINERCLI_USAGE.md
@@ -175,7 +175,8 @@ approve/drop。逐条质量审批属于后处理：WebAgent 的 L2 `domain_class
 且带有 grounded 语义信号的条目，随后由 `topic_quality_filter` 按置信度与信号
 阈值把关。生产出湖前必须完成 DataFlowAgent 后处理（`dm dataflow
 agent-run`，产出 L4 数据）；湖内每个能力桶可用量至少为出湖目标的 1.5 倍，
-且 L4 最终规模达标后才允许调用 `sft-export-agent`。来源 URI、数据集 ID 和
+且 L4 最终规模达标后才允许调用 `sft-export-agent`。若用户明确指定 L3 出湖，
+则跳过 L4 门，L3 数据可直接出湖。来源 URI、数据集 ID 和
 source 名称只作为 provenance 与质量报告审计信息，不参与接受或拒绝。
 
 金融入湖示例：
@@ -194,7 +195,7 @@ loopai-obtainercli dm --root /data/lakes/finance/warehouse ingest sec_finance \
 行标签中，不构成出湖接受或拒绝的依据。出湖质量由后处理主线把关：先完成
 DataFlowAgent 后处理（`dm dataflow agent-run`，产出 L4 数据），湖内每个能力桶
 可用量至少为出湖目标的 1.5 倍，且 L4 最终规模达标后才允许调用
-`sft-export-agent`。
+`sft-export-agent`。若用户明确指定 L3 出湖，则跳过 L4 门，L3 数据可直接出湖。
 
 底层 SearchAgent 与下载命令仍保留为采集桥，但只供 worker 内部调用或人工调试。
 外层 Codex 在正常工作流中不要创建 task JSON、不要直接调用 `searchagent`，也不要直接调用 `download manifest`。

--- a/docs/mineruhtml_deploy.md
+++ b/docs/mineruhtml_deploy.md
@@ -1,0 +1,268 @@
+# MinerU-HTML 部署教程（可复用，适用于任意 Linux + NVIDIA GPU 机器）
+
+> 版本：MinerU-HTML v1.1（hunyuan0.5B-compact）
+> 用途：HTML 主内容提取（网页正文 → Markdown），作为 DataMixer `webpage_to_pt` 正文提取算子的 HTTP 服务（默认端口 7986）。
+> 本文是**通用教程**：不绑定任何一台机器的具体路径。所有命令使用统一的环境变量，先按目标机器修改一次（§0.2），即可整段复制执行。
+
+---
+
+## 0. 前置条件与路径规划（先看这一节）
+
+### 0.1 前置条件
+- Linux 系统，NVIDIA GPU（驱动可用，`nvidia-smi` 能正常输出）
+- conda / miniconda（用于创建 Python 3.10 环境）
+- 能访问外网：pip 与 HuggingFace 下载（国内可用镜像，见 §2.2 / §3.1）
+- 目标端口（默认 `7986`）未被占用
+
+### 0.2 统一路径变量（按你的机器改一次）
+
+下文所有命令都引用这些变量，避免把路径写死。把 `<...>` 替换成目标机器的真实值：
+
+```bash
+# ================= 按你的机器修改 =================
+export MINERU_PROJECT_DIR="<项目目录>"        # 例：/home/user/code/Dataflow-LoopAI（需含 scripts/ 目录）
+export MINERU_CONDA_PREFIX="<conda 环境路径>" # 例：/opt/conda/envs/mineruhtml
+export MINERU_MODEL_DIR="<模型存放目录>"       # 例：/home/user/models/MinerU-HTML-v1.1-hunyuan0.5B-compact
+export MINERU_PORT="7986"                      # 服务端口
+export MINERU_GPU="0"                          # 物理 GPU 编号（CUDA_VISIBLE_DEVICES）
+export MINERU_LOG_DIR="<日志目录>"             # 例：/var/log/mineruhtml
+# =================================================
+
+mkdir -p "$MINERU_LOG_DIR"
+```
+
+> 建议把上面这段保存为 `mineruhtml.env`，每次新开 shell 用 `source mineruhtml.env` 加载，保证所有命令里的变量一致。
+
+| 变量 | 含义 | 示例 |
+|---|---|---|
+| `MINERU_PROJECT_DIR` | 项目根目录（含 `scripts/mineruhtml_server.py`） | `/home/user/code/Dataflow-LoopAI` |
+| `MINERU_CONDA_PREFIX` | conda 环境绝对路径（`conda env list` 可查） | `/opt/conda/envs/mineruhtml` |
+| `MINERU_MODEL_DIR` | 模型目录 | `/home/user/models/MinerU-HTML-v1.1-hunyuan0.5B-compact` |
+| `MINERU_PORT` | 服务端口 | `7986` |
+| `MINERU_GPU` | 物理 GPU 编号 | `0` |
+| `MINERU_LOG_DIR` | 日志目录 | `/var/log/mineruhtml` |
+
+---
+
+## 1. 概述
+
+MinerU-HTML 是基于 SLM（Tencent Hunyuan 0.5B，256k 上下文）的 HTML 主内容提取工具：
+- 从复杂网页 HTML 中**识别并提取正文**，过滤导航栏、广告、页脚、元信息等
+- 输出 **Markdown**（`mm_md` 格式），可直接用于下游 PT/SFT 数据构建
+- 本部署用 **vLLM** 作为推理后端，暴露 FastAPI 服务（`/health`、`/extract`）
+
+### 架构
+```
+网页 HTML ──POST /extract──▶ FastAPI(mineruhtml_server.py)
+                                └── mineru-html(MinerUHTMLGeneric)
+                                      └── vLLM backend
+                                            └── MinerU-HTML-v1.1-hunyuan0.5B-compact (GPU)
+```
+
+### 与项目的对应关系
+| 组件 | 位置 |
+|---|---|
+| Conda 环境 | `$MINERU_CONDA_PREFIX`（Python 3.10） |
+| 模型目录 | `$MINERU_MODEL_DIR` |
+| 启动脚本 | `$MINERU_PROJECT_DIR/scripts/mineruhtml_server.py`（vLLM HTTP 服务） |
+| 管理脚本 | `$MINERU_PROJECT_DIR/scripts/mineruhtml.sh`（start/stop/status） |
+| 服务端口 | `$MINERU_PORT`（与 DataMixer `mineru_url` 对应） |
+
+---
+
+## 2. 环境准备
+
+### 2.1 创建 Conda 环境（Python 3.10）
+```bash
+conda create -n mineruhtml python=3.10 -y
+conda activate mineruhtml
+
+# 记住环境绝对路径，填到 §0.2 的 MINERU_CONDA_PREFIX
+conda env list
+```
+
+### 2.2 安装依赖
+```bash
+# 核心推理栈（注意版本匹配，vLLM 0.11.x 需 torch>=2.8）
+pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0
+pip install "vllm==0.11.1" "transformers>=4.57"
+pip install "mineru-html==1.1.2" "mineru-webkit==0.1.6"
+pip install fastapi uvicorn pydantic
+```
+> 若 pip 慢，可加 `-i https://pypi.tuna.tsinghua.edu.cn/simple`；HuggingFace 下载慢用 `hf-mirror.com`（见下）。
+
+---
+
+## 3. 模型下载
+
+模型仓库：**`opendatalab/MinerU-HTML-v1.1-hunyuan0.5B-compact`**（HuggingFace）
+> 这是 Tencent Hunyuan 0.5B 的派生模型，compact 输出格式，支持 vLLM v1 backend，256k 上下文。
+
+### 3.1 用 huggingface-cli 下载到本地
+```bash
+export HF_ENDPOINT=https://hf-mirror.com   # 国内镜像（可选但推荐）
+export HF_HOME="$MINERU_MODEL_DIR/.hf_cache"
+
+huggingface-cli download opendatalab/MinerU-HTML-v1.1-hunyuan0.5B-compact \
+    --local-dir "$MINERU_MODEL_DIR"
+```
+
+### 3.2 模型文件清单（下载后应包含）
+```
+$MINERU_MODEL_DIR/
+├── config.json            # HunYuanDenseV1ForCausalLM, hidden=1024, bf16
+├── generation_config.json
+├── model.safetensors      # 权重（约 1GB，bf16）
+├── tokenizer.json / tokenizer_config.json
+├── chat_template.jinja
+├── special_tokens_map.json
+├── README.md / LICENSE / NOTICE.txt
+```
+> 校验：`config.json` 中 `architectures: ["HunYuanDenseV1ForCausalLM"]`，`dtype: bfloat16`。
+
+---
+
+## 4. vLLM 部署（两种方式）
+
+### 方式 A：`mineruhtml_server.py`（推荐，独立 FastAPI 服务）
+
+#### 4.A.1 直接运行
+```bash
+"$MINERU_CONDA_PREFIX/bin/python" \
+    "$MINERU_PROJECT_DIR/scripts/mineruhtml_server.py" \
+    --model "$MINERU_MODEL_DIR" \
+    --port "$MINERU_PORT" \
+    --gpu "$MINERU_GPU" \
+    --gpu-memory-utilization 0.3 \
+    --max-context-window 8192 \
+    --max-tokens 2048 \
+    --fallback trafilatura \
+    --output-format mm_md
+```
+
+**参数说明**
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `--model` | 脚本内置默认路径（建议总是显式指定） | 本地模型目录（`$MINERU_MODEL_DIR`） |
+| `--host` / `--port` | `0.0.0.0` / `7986` | 监听地址与端口 |
+| `--gpu` | `0` | 物理 GPU 编号（`CUDA_VISIBLE_DEVICES`） |
+| `--gpu-memory-utilization` | `0.3` | vLLM 显存占用比例（小模型 0.3 足够，避免挤占其他任务） |
+| `--max-context-window` | `8192` | 模型上下文窗口（模型支持 256k，可按需调大） |
+| `--max-tokens` | `2048` | 单次生成最大 token |
+| `--fallback` | `trafilatura` | 提取失败时的兜底策略：`trafilatura` / `bypass` / `empty` |
+| `--output-format` | `mm_md` | 输出格式（Markdown） |
+
+> 该脚本也支持同名环境变量（未显式传参时读取）：`MINERU_HTML_MODEL`、`MINERU_HTML_HOST`、`MINERU_HTML_PORT`、`MINERU_HTML_GPU`、`MINERU_HTML_GPU_MEMORY_UTILIZATION`、`MINERU_HTML_MAX_CONTEXT_WINDOW`、`MINERU_HTML_MAX_TOKENS`、`MINERU_HTML_FALLBACK`、`MINERU_HTML_OUTPUT_FORMAT`。例如把 §0.2 的变量再映射一份后，可以不带参数直接启动，适合写进 systemd / supervisor：
+> ```bash
+> export MINERU_HTML_MODEL="$MINERU_MODEL_DIR"
+> export MINERU_HTML_PORT="$MINERU_PORT"
+> export MINERU_HTML_GPU="$MINERU_GPU"
+> "$MINERU_CONDA_PREFIX/bin/python" "$MINERU_PROJECT_DIR/scripts/mineruhtml_server.py"
+> ```
+
+#### 4.A.2 后台启动
+```bash
+mkdir -p "$MINERU_LOG_DIR"
+setsid nohup "$MINERU_CONDA_PREFIX/bin/python" \
+    "$MINERU_PROJECT_DIR/scripts/mineruhtml_server.py" \
+    --model "$MINERU_MODEL_DIR" \
+    --port "$MINERU_PORT" --gpu "$MINERU_GPU" \
+    > "$MINERU_LOG_DIR/mineruhtml.log" 2>&1 < /dev/null &
+```
+
+### 方式 B：`mineruhtml.sh`（dripper 服务，start/stop/status）
+
+```bash
+"$MINERU_PROJECT_DIR/scripts/mineruhtml.sh" start     # 启动（dripper.server，INFERENCE_BACKEND=vllm）
+"$MINERU_PROJECT_DIR/scripts/mineruhtml.sh" status    # 查状态
+"$MINERU_PROJECT_DIR/scripts/mineruhtml.sh" stop      # 停止
+```
+> 该脚本基于自身位置推断项目根目录（`scripts/` 的上一级），因此**整个项目目录拷到目标机器即可**，无需改路径。
+> 它默认使用项目内 `envs/.mineruhtml`（Python 环境 + `dripper` 源码）和 `model/mineru-html` 子目录；端口、GPU、模型初始化参数可通过 `MINERUHTML_PORT`、`MINERUHTML_CUDA_VISIBLE_DEVICES`、`MINERUHTML_MODEL_INIT_KWARGS` 覆盖。
+> 推荐用**方式 A**（conda env + `mineruhtml_server.py`，路径完全由 §0.2 变量控制），方式 B 适用于项目自带的 venv 结构。
+
+---
+
+## 5. 验证
+
+### 5.1 健康检查
+```bash
+curl "http://127.0.0.1:$MINERU_PORT/health"
+# {"status":"ok"}
+```
+
+### 5.2 提取测试
+```bash
+curl -X POST "http://127.0.0.1:$MINERU_PORT/extract" \
+  -H 'Content-Type: application/json' \
+  -d '{"html": "<html><body><h1>标题</h1><p>这是正文内容。</p><div class=\"ad\">广告</div></body></html>"}'
+```
+响应示例：
+```json
+{
+  "main_html": "...",
+  "main_content": "# 标题\n\n这是正文内容。\n",
+  "error": null
+}
+```
+> `main_content` 为提取后的 Markdown；提取失败时 `error` 非空（配合 `--fallback` 兜底）。
+
+---
+
+## 6. 与 LoopAI / DataMixer 集成
+
+在 DataMixer 的 `starter.yaml`（或 pipeline.yaml）中配置：
+```yaml
+# 同机部署
+mineru_url: http://127.0.0.1:7986
+
+# 服务在其他机器时，改成该机器 IP（保证服务 --host 0.0.0.0 且防火墙放行端口）
+# mineru_url: http://<服务机IP>:7986
+```
+- DataMixer 的 `webpage_to_pt` 算子（`mineru_transport: http`）会调用本服务的 `/extract`
+- 网页采集 → MinerU-HTML 提取正文 → 生成 L1/L2 文本 → 进入后续 PT/SFT 流水线
+
+---
+
+## 7. 运维
+
+| 操作 | 命令 |
+|---|---|
+| 查看日志 | `tail -f "$MINERU_LOG_DIR/mineruhtml.log"`（方式 A） |
+| 停止 | 方式 A：`pkill -f mineruhtml_server.py`；方式 B：`"$MINERU_PROJECT_DIR/scripts/mineruhtml.sh" stop` |
+| 换 GPU | 启动时改 `--gpu N`（或 `MINERUHTML_CUDA_VISIBLE_DEVICES`） |
+| 显存紧张 | 调低 `--gpu-memory-utilization`（vLLM 会预留该比例） |
+
+### 常见问题
+| 现象 | 处理 |
+|---|---|
+| `/health` 无响应 | 检查端口是否被占：`ss -tlnp \| grep "$MINERU_PORT"`；看日志有无 vLLM 加载报错 |
+| vLLM 加载 OOM | 降低 `--gpu-memory-utilization`，或换空闲 GPU |
+| `/extract` 返回 500 | 看 `error` 字段；尝试 `--fallback bypass` 或换 `--output-format` |
+| 中文网页提取差 | 调大 `--max-context-window`（模型支持 256k） |
+| 远程访问不通 | 确认服务 `--host 0.0.0.0`、防火墙放行 `$MINERU_PORT`、调用方 `mineru_url` 使用服务机 IP |
+
+---
+
+## 8. 快速参考（一条命令部署）
+
+```bash
+# 0) 加载路径变量（见 §0.2，按你的机器修改）
+source mineruhtml.env
+
+# 1) 模型（已下载则跳过）
+export HF_ENDPOINT=https://hf-mirror.com
+huggingface-cli download opendatalab/MinerU-HTML-v1.1-hunyuan0.5B-compact \
+    --local-dir "$MINERU_MODEL_DIR"
+
+# 2) 启动（GPU $MINERU_GPU，端口 $MINERU_PORT）
+mkdir -p "$MINERU_LOG_DIR"
+setsid nohup "$MINERU_CONDA_PREFIX/bin/python" \
+    "$MINERU_PROJECT_DIR/scripts/mineruhtml_server.py" \
+    --model "$MINERU_MODEL_DIR" \
+    --port "$MINERU_PORT" --gpu "$MINERU_GPU" \
+    > "$MINERU_LOG_DIR/mineruhtml.log" 2>&1 < /dev/null &
+
+# 3) 验证
+curl "http://127.0.0.1:$MINERU_PORT/health"
+```

--- a/loopai/agents/Obtainer/datamixer/codex.py
+++ b/loopai/agents/Obtainer/datamixer/codex.py
@@ -20,6 +20,7 @@ import selectors
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from functools import lru_cache
 from pathlib import Path
@@ -380,8 +381,22 @@ def _run_loopai_codex_runner(
         raise CodexError("LoopAI codex-runner not found")
     if not corepack:
         raise CodexError("corepack not found; install Node.js with Corepack to use the Codex engine")
-    cmd = [corepack, "yarn", "dev", prompt]
+    # Prompt is delivered via a temp file (runner reads CODEX_PROMPT_FILE) to
+    # avoid execve ARG_MAX limits when the prompt is large; stdin is unreliable
+    # through corepack/yarn's nested process spawns.
+    fd, prompt_path = tempfile.mkstemp(prefix="codex_prompt_", suffix=".txt", text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(prompt)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    cmd = [corepack, "yarn", "dev", "-"]
     merged_env = {**os.environ, **env}
+    merged_env["CODEX_PROMPT_FILE"] = prompt_path
     python_executable = loopai_python_executable()
     merged_env["LOOPAI_PYTHON_EXECUTABLE"] = python_executable
     merged_env["PATH"] = runner_process_path(python_executable, merged_env.get("PATH"))
@@ -438,7 +453,13 @@ def _run_loopai_codex_runner(
     finally:
         selector.close()
 
-    return proc.wait(), "".join(stdout_lines), "".join(stderr_lines)
+    try:
+        return proc.wait(), "".join(stdout_lines), "".join(stderr_lines)
+    finally:
+        try:
+            os.unlink(prompt_path)
+        except OSError:
+            pass
 
 
 def _parse_json_object(text: str) -> dict | None:

--- a/loopai/agents/Obtainer/datamixer/dataflow_agent.py
+++ b/loopai/agents/Obtainer/datamixer/dataflow_agent.py
@@ -130,7 +130,8 @@ DATAFLOW_AGENTS_MD = """# LoopAI DataMixer DataFlow Agent
 
 你是 DataMixer 的 **DataFlow 后处理 agent**（dataflow agent），负责把 L1 -> L2
 -> L3 链路上的数据通过 DataFlow operator 链处理成 **L4**（质量过滤、去重、
-规范化、安全、SFT 有效性），L4 是生产导出的唯一数据源。
+规范化、安全、SFT 有效性），默认情况下 L4 是生产出湖的数据源；若用户明确
+指定 L3 出湖，则 L3 数据也可直接出湖，无需 L4 门。
 
 ## 运行环境清单
 
@@ -162,7 +163,8 @@ DATAFLOW_AGENTS_MD = """# LoopAI DataMixer DataFlow Agent
    不在你的职责范围。
 4. L4 规模必须达标（整体与每个 bucket 都 >= 配比目标的 1.5x）才允许外层启动
    `sft-export-agent` 出湖；规模不达标前禁止出湖。这是上层的出湖门，你在
-   交付 summary 里说明桶规模与预期冗余即可。
+   交付 summary 里说明桶规模与预期冗余即可。若用户明确指定 L3 出湖，则跳过
+   L4 门，L3 数据可直接出湖（仍需满足湖内可用量/配比/质量门）。
 
 ## 硬约束
 

--- a/loopai/agents/Obtainer/datamixer/dataflow_agent.py
+++ b/loopai/agents/Obtainer/datamixer/dataflow_agent.py
@@ -64,10 +64,15 @@ def parse_llm_scalar_score(value: Any, *, minimum: int = 1, maximum: int = 5) ->
     text = str(value).strip()
     answer_blocks = re.findall(r"<answer>(.*?)</answer>", text, flags=re.DOTALL | re.IGNORECASE)
     if answer_blocks:
-        if len(answer_blocks) != 1:
-            raise ValueError("LLM score response has multiple <answer> blocks")
-        text = answer_blocks[0].strip()
+        # Use the LAST <answer> block (innermost), which is the model's actual answer.
+        # The API helper may wrap thinking/reasoning + answer tags around the model output
+        # where content already has <answer> tags, creating nested wrapping.
+        # Strip all <answer></answer> tags from the extracted text to get the raw score.
+        text = re.sub(r'</?answer\s*>', '', answer_blocks[-1], flags=re.IGNORECASE).strip()
     else:
+        # Strip any remaining <answer>/</answer> tags before parsing
+        text = re.sub(r'</?answer\s*>', '', text, flags=re.IGNORECASE).strip()
+        text = re.sub(r'answer\s*>', '', text, flags=re.IGNORECASE).strip()
         text = re.sub(
             r"<think>.*?</think>", "", text,
             flags=re.DOTALL | re.IGNORECASE,

--- a/loopai/common/event_tool/__init__.py
+++ b/loopai/common/event_tool/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import pickle
-import uuid
 from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _new_version_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
 
 
 def _sanitize_path_component(value: str, fallback: str) -> str:
@@ -239,7 +242,7 @@ class PickleEventWriter:
         return self.version_id
 
     def new_version_id(self) -> str:
-        return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+        return _new_version_id()
 
     def _sync_runtime(self, *, status: str) -> None:
         try:
@@ -296,7 +299,7 @@ def get_event_writer(
 ) -> PickleEventWriter:
     agent_name = _sanitize_path_component(name, "agent")
     context_value = _sanitize_path_component(context_id, "default")
-    version_value = _sanitize_path_component(version_id or str(uuid.uuid4()), "version")
+    version_value = _sanitize_path_component(version_id or _new_version_id(), "version")
     base_path = Path(log_file_path)
     if event_dir is not None:
         event_path = Path(event_dir) / f"{agent_name}.pkl"

--- a/loopai/skills/ObtainerCLI/dataset_acquisition_agent.py
+++ b/loopai/skills/ObtainerCLI/dataset_acquisition_agent.py
@@ -178,7 +178,16 @@ Hard rules:
    `--source-row-count <n>` to `dm ingest` so DataMixer validates this before
    writing. If validation fails, fix the normalizer or reject the dataset; do
    not ingest partial rows.
-13. Ingest every accepted dataset through DataMixer `ingest` or `agent-ingest`
+13. If the user request or Analyzer report explicitly names a benchmark type to
+   collect (for example "collect HumanEval-style code problems", "BIRD SQL
+   pairs", or any named eval/test set), treat that dataset as evaluation-only
+   and register it in the DataMixer benchmark registration layer BEFORE any
+   acquisition or ingest:
+   {python_executable} -m loopai.skills.ObtainerCLI.cli dm --root {warehouse} contam add --name <benchmark> --file <file> --json
+   The registration makes downstream ingest and export decontamination exclude
+   those rows and prevents benchmark leakage into training data. Do not rely
+   on a later `decontaminate` pass alone to decide what to register.
+14. Ingest every accepted dataset through DataMixer `ingest` or `agent-ingest`
    with complete tags: source platform, source dataset id, source URL or URI,
    license if known, language if known, domain, task_type, processing_level,
    quality_level, source_kind, split, loop_uuid/version_id when provided, and
@@ -188,21 +197,21 @@ Hard rules:
    must be L3, not L1), and L4 only for output explicitly refined by an
    internal data-lake pipeline. When uncertain, choose the lower applicable
    level and explain the uncertainty; never omit the parameter.
-14. After ingest, run DataMixer status, dataset list, stats, representative query,
+15. After ingest, run DataMixer status, dataset list, stats, representative query,
    and index build when useful for downstream recall.
-15. Write final_report.json with `lake_ready`, per-bucket planned-versus-observed
+16. Write final_report.json with `lake_ready`, per-bucket planned-versus-observed
     record/token counts, quality-gate evidence, SearchAgent and WebAgent commands/statuses,
     WebAgent campaign id and L1 datasets, candidates, filtered list, rejections,
     downloads, dataset card paths, derived field specs, validation outcomes,
     ingests, each dataset's selected quality_level and selection rationale,
     DataMixer command summaries, before/after counts, lineage/manifest paths,
     and blockers.
-16. Do not mark ok=true if no dataset was ingested, if accepted datasets are
+17. Do not mark ok=true if no dataset was ingested, if accepted datasets are
     unrelated to the request, if any accepted dataset lacks a registered md
     dataset card, if derived field validation failed, if row count changed
     during derivation, or if required source/provenance tags are missing.
-17. Do not read or print secret/key files.
-18. Per-record quality approval belongs to post-processing: the WebAgent L2
+18. Do not read or print secret/key files.
+19. Per-record quality approval belongs to post-processing: the WebAgent L2
     `domain_classify` step receives the campaign `--focus-keywords` and the LLM
     judgement accepts only items directly related to that focus, backed by
     grounded semantic signals; `topic_quality_filter` then enforces a

--- a/loopai/skills/ObtainerCLI/orchestrator_agent.py
+++ b/loopai/skills/ObtainerCLI/orchestrator_agent.py
@@ -115,7 +115,9 @@ Hard rules:
    Phases: bootstrap -> acquiring -> gating -> dataflow -> exporting -> finalizing.
 4. Dispatch, never micromanage: start `dataset-acquisition-agent`, poll it and
    the lake metrics; when the volume/mix/quality gates pass, run
-   `dataflow agent-run`; when the L4 gate passes, start `sft-export-agent`.
+   `dataflow agent-run`; when the L4 gate passes, start `sft-export-agent`
+   (if the user explicitly specifies an L3 export, skip the L4 gate and start
+   `sft-export-agent` directly once the volume/mix/quality gates pass).
    Poll each worker by run_dir and resume it when it reports a resumable state.
 5. **Parallel advancement is a HARD RULE - never wait serially.** Once the
    `lake_volume` gate passes (the lake meets the plan's volume/mix/quality
@@ -123,7 +125,10 @@ Hard rules:
    `dataset-acquisition-agent` to finish. The acquisition worker keeps running
    in the background and its extra candidates only help. Record BOTH subtasks
    (`acquisition` + `dataflow`) in phase. Only the DataFlow L4 output gates
-   `sft-export-agent`; that export worker also starts as soon as L4 is ready.
+   `sft-export-agent` by default; that export worker also starts as soon as L4
+   is ready. When the user explicitly specifies an L3 export, the L4 gate is
+   skipped and `sft-export-agent` starts once the volume/mix/quality gates
+   pass.
 5. On completion write final_report.json with warehouse, datasets, record
    counts, recipe/export artifacts, lineage, manifests and snapshots, then
    set `--state completed --phase finalizing --next-action report`.

--- a/skills/obtainer/SKILL.md
+++ b/skills/obtainer/SKILL.md
@@ -34,7 +34,9 @@ not a generic coding task:
    deduplication, normalization, safety, and post-training validity).
 5. Only after the DataFlowAgent run completes and the final L4 dataset scale
    meets the recipe target, start the managed `sft-export-agent` worker for
-   production SFT outflow.
+   production SFT outflow. If the user explicitly specifies an L3 export, the
+   L4 gate is waived and L3 data may be exported directly once the lake
+   volume/mix/quality gates pass.
 6. Report warehouse path, datasets, record counts, recipe/export artifacts,
    lineage, manifests, and snapshots.
 
@@ -201,27 +203,33 @@ Never judge progress from `message` alone; use the structured fields.
   per-bucket record/token counts and the planned quality gates. As soon as the
   lake satisfies the required volume, mix, and quality, immediately start the
   DataFlowAgent post-processing stage and required indexing and recipe planning;
-  start production export only after the L4 gate below passes. Never use
+  start production export only after the L4 gate below passes (or directly,
+  when the user explicitly specifies an L3 export). Never use
   WebAgent completion, acquisition-worker completion, or empty producer queues
   as prerequisites; keep those producers running concurrently.
-- **DataFlowAgent is a mandatory pre-export gate.** Every production export
-  must first complete the DataFlowAgent post-processing stage
+- **DataFlowAgent is a mandatory pre-export gate by default.** Every
+  production export must first complete the DataFlowAgent post-processing stage
   (`dm dataflow agent-run`), which delivers a trial-verified L4 pipeline; the
   outer Codex then executes it over the exported 1.5x bucket-buffer input with
   the chunked runner to produce the L4 dataset. L4 is the DataFlow-processed
   level on top of the L1 -> L2 -> L3 chain (raw webpages -> normalized PT ->
-  SFT QA -> post-processed) and is the only sample source for production
+  SFT QA -> post-processed) and is the default sample source for production
   export. Skipping, deferring, or folding this stage into the export worker is
-  not allowed; an export without a completed L4 source is a blocker.
+  not allowed; an export without a completed L4 source is a blocker. If the
+  user explicitly specifies an L3 export, the L4 gate is waived and L3 data
+  may be exported directly instead.
 - **1.5x in-lake redundancy is a hard requirement.** To guarantee that the
   export mix can be met, the lake must hold at least 1.5x the recipe target
   volume both overall and per bucket (`available_samples >= 1.5 x
   target_samples` for every bucket). If any bucket falls below this floor,
   continue acquisition and DataFlow post-processing until the redundancy is
   satisfied; never export a mix from a non-redundant lake.
-- **L4 scale gates export.** The DataFlowAgent stage is considered complete only
-  when the final L4 dataset scale meets the recipe target (overall and per
-  bucket, after the 1.5x redundancy floor). Only then call `sft-export-agent`.
+- **L4 scale gates export by default.** The DataFlowAgent stage is considered
+  complete only when the final L4 dataset scale meets the recipe target
+  (overall and per bucket, after the 1.5x redundancy floor). Only then call
+  `sft-export-agent`. If the user explicitly specifies an L3 export, this L4
+  scale gate is waived and L3 data may be exported once the lake
+  volume/mix/quality gates pass.
 - **WebAgent model prerequisite:** the wrapper resolves the Codex default model,
   registers that same provider in the DataMixer model pool, and records
   `resolved_model`, `webagent_model`, and `model_source` in `thread.json`.
@@ -292,6 +300,15 @@ Never judge progress from `message` alone; use the structured fields.
   before ingest succeeds.
 - **Never overwrite or hide provenance.** Keep dataset lineage, loop/version
   tags, recipe fingerprints, export manifests, and snapshots.
+- **Register user-named benchmarks before acquisition/ingest.** If the user
+  query or Analyzer report explicitly names the benchmark type to collect (for
+  example "collect HumanEval-style code problems", "BIRD SQL pairs", or any
+  named eval/test set), treat that dataset as evaluation-only and register it
+  in the DataMixer benchmark registration layer (`dm contam add --name
+  <benchmark> --file <file>`) before any acquisition or ingest, so downstream
+  ingest and export decontamination exclude it and benchmark data cannot leak
+  into training data. Do not rely on a later `decontaminate` pass alone to
+  decide what to register.
 
 ## Command Surface
 
@@ -450,6 +467,12 @@ loopai-obtainercli dm --root /path/to/warehouse grade \
 
 Processing, quality, safety, and deletion:
 
+When the user query or Analyzer report explicitly names a benchmark/eval
+dataset type to collect, register it in the benchmark registration layer
+first with `contam add` before any acquisition or ingest; the subsequent
+`decontaminate` pass then excludes those rows from downstream training export
+and prevents benchmark leakage.
+
 ```bash
 loopai-obtainercli dm --root /path/to/warehouse op list --json
 loopai-obtainercli dm --root /path/to/warehouse op run quality_score --dataset code_repair_mix --json
@@ -544,7 +567,8 @@ DataFlowAgent agent-run rules:
   quality-evaluation operators score every row - let it finish.
 - The agent runs with its own Codex home (`codex_home_dataflow/AGENTS.md`),
   whose rules require it to deliver the trial-verified pipeline (never launch
-  the full run itself) and to gate export on the 1.5x L4 redundancy floor.
+  the full run itself) and to gate export on the 1.5x L4 redundancy floor
+  (skipped when the user explicitly specifies an L3 export).
 
 Index and recall:
 
@@ -705,7 +729,8 @@ explicitly instead of letting a global mapping choose the wrong source.
    post-training validity; it delivers a trial-verified pipeline, then the
    outer Codex runs it over `full_input.jsonl` with the chunked runner
    (`dataflow_chunked_runner --chunk-size 10000`) and merges the L4 output
-   with `apply-jsonl`. L4 must be produced before any export.
+   with `apply-jsonl`. L4 must be produced before any export (unless the user
+   explicitly requests an L3 export).
 5. Build indexes when semantic recall or semantic deduplication is needed.
 6. Start `sft-export-agent` for production recipe planning and export only after
    the DataFlowAgent stage completed and the L4 dataset scale meets the recipe

--- a/tests/test_trainer_run_identity.py
+++ b/tests/test_trainer_run_identity.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 
 from api.app.services.starter.stream_events import build_custom_info
 from loopai.common.event_tool import get_event_writer
@@ -158,3 +159,14 @@ def test_status_reader_supports_legacy_versioned_event_path(tmp_path: Path) -> N
     )
 
     assert custom_info["trainer.trainer.run"]["version_id"] == "legacy-version"
+
+def test_get_event_writer_defaults_to_timestamp_version_id(tmp_path: Path) -> None:
+    writer = get_event_writer(
+        name="analyzer",
+        context_id="task-1",
+        log_file_path=str(tmp_path),
+    )
+
+    version_id = str(writer.version_id)
+    assert re.fullmatch(r"\d{8}_\d{6}_\d{6}", version_id)
+    assert writer.event_path == tmp_path / "task-1" / "analyzer" / version_id / "analyzer.pkl"

--- a/ui/src/components/manage/mainFlow/nodes/agentNode/custom/obtainerStatusPannel.vue
+++ b/ui/src/components/manage/mainFlow/nodes/agentNode/custom/obtainerStatusPannel.vue
@@ -44,11 +44,16 @@
                     :key="item.export_id || item.output_uri"
                     class="export-row"
                     :class="{ copied: copiedExport === item.output_uri }"
-                    :title="`${exportLabel(item)}：${item.output_uri}（点击复制）`"
-                    @click="copyText(item.output_uri)"
                 >
-                    <span class="export-name">{{ exportLabel(item) }}</span>
-                    <span class="export-path">{{ item.output_uri }}</span>
+                    <div class="export-main" :title="`${exportLabel(item)}：${item.output_uri}（点击复制）`" @click="copyText(item.output_uri)">
+                        <span class="export-name">{{ exportLabel(item) }}</span>
+                        <span class="export-path">{{ item.output_uri }}</span>
+                        <span v-if="exportDesc(item)" class="export-desc">{{ exportDesc(item) }}</span>
+                    </div>
+                    <div class="export-actions" @click.stop>
+                        <button type="button" class="export-btn" @click="previewExport(item)">预览</button>
+                        <button type="button" class="export-btn" @click="downloadExport(item)">下载</button>
+                    </div>
                 </div>
             </div>
             <p v-else class="empty-line">暂无出湖产出</p>
@@ -154,6 +159,36 @@
 
             <p v-if="dataflow.error" class="error-line" :title="dataflow.error">{{ dataflow.error }}</p>
         </section>
+
+        <div v-if="previewState" class="export-preview-mask" @click.self="closePreview">
+            <div class="export-preview-panel">
+                <header class="export-preview-head">
+                    <strong>出湖预览{{ previewState.file ? `：${previewState.file}` : '' }}</strong>
+                    <button type="button" class="export-btn" @click="closePreview">关闭</button>
+                </header>
+                <div v-if="previewState.loading" class="export-preview-loading">加载中…</div>
+                <div v-else-if="previewState.error" class="export-preview-error">{{ previewState.error }}</div>
+                <div v-else>
+                    <div v-if="previewState.description" class="export-preview-desc">
+                        <p v-if="previewState.description.recipe_name">Recipe：{{ previewState.description.recipe_name }}</p>
+                        <p v-if="previewState.description.records">记录数：{{ exactNumber(previewState.description.records) }}</p>
+                        <p v-if="previewState.description.total_samples">目标样本：{{ exactNumber(previewState.description.total_samples) }}</p>
+                        <p v-if="previewState.description.strategy">策略：{{ previewState.description.strategy }}</p>
+                        <p v-if="previewState.description.buckets?.length">分桶：{{ previewState.description.buckets.join(' / ') }}</p>
+                        <p v-if="previewState.description.snapshot_id">快照：{{ previewState.description.snapshot_id }}</p>
+                    </div>
+                    <table v-if="previewState.rows.length" class="export-preview-table">
+                        <thead><tr><th v-for="c in previewState.columns" :key="c">{{ c }}</th></tr></thead>
+                        <tbody>
+                            <tr v-for="(row, i) in previewState.rows" :key="i">
+                                <td v-for="c in previewState.columns" :key="c" :title="cellText(row[c])">{{ cellText(row[c]) }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <p v-else class="empty-line">无数据</p>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -241,6 +276,45 @@ const exportLabel = (item) => {
     return '出湖'
 }
 const copiedExport = ref('')
+const previewState = ref(null)
+const exportDesc = (item) => {
+    const d = item.description || {}
+    const parts = []
+    if (d.records) parts.push(`${exactNumber(d.records)} 条`)
+    if (d.total_samples) parts.push(`目标 ${exactNumber(d.total_samples)}`)
+    if (d.recipe_name) parts.push(d.recipe_name)
+    if (Array.isArray(d.buckets) && d.buckets.length) parts.push(d.buckets.join(' / '))
+    return parts.join(' · ')
+}
+const cellText = (v) => {
+    const s = v === null || v === undefined ? '' : String(v)
+    return s.length > 80 ? `${s.slice(0, 80)}…` : s
+}
+const previewExport = async (item) => {
+    previewState.value = { loading: true, description: item.description || null, columns: [], rows: [], error: '', file: '' }
+    try {
+        const url = `/api/obtainer/export/preview?uri=${encodeURIComponent(item.output_uri || '')}&limit=20`
+        const res = await fetch(url)
+        const data = await res.json()
+        const payload = data?.data || {}
+        previewState.value = {
+            loading: false,
+            description: payload.description || item.description || null,
+            columns: payload.columns || [],
+            rows: payload.rows || [],
+            error: data?.message || '',
+            file: payload.file || ''
+        }
+    } catch (err) {
+        previewState.value = { loading: false, description: null, columns: [], rows: [], error: err?.message || '预览失败', file: '' }
+    }
+}
+const closePreview = () => { previewState.value = null }
+const downloadExport = (item) => {
+    const uri = item.output_uri || ''
+    if (!uri) return
+    window.open(`/api/obtainer/export/download?uri=${encodeURIComponent(uri)}`, '_blank')
+}
 let copyTimer = null
 const copyText = async (text) => {
     const value = normalizeText(text)
@@ -481,6 +555,25 @@ onBeforeUnmount(() => {
 .dataflow-context .inline-metric { grid-template-columns: 105px minmax(0, 1fr); }
 .task-feedback { max-height: 108px; overflow: hidden; }
 
+
+.export-row { display: flex; flex-direction: column; gap: 4px; padding: 6px 2px; border-bottom: 1px solid rgba(90, 45, 133, 0.09); }
+.export-main { cursor: pointer; display: grid; gap: 2px; }
+.export-desc { font-size: 10px; color: rgba(65, 65, 65, 0.55); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.export-actions { display: flex; gap: 6px; }
+.export-btn { font-size: 10px; padding: 2px 8px; border: 1px solid rgba(90, 45, 133, 0.35); border-radius: 4px; background: rgba(90, 45, 133, 0.06); color: rgba(90, 45, 133, 0.85); cursor: pointer; }
+.export-btn:hover { background: rgba(90, 45, 133, 0.14); }
+.export-preview-mask { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.35); z-index: 9999; display: flex; align-items: center; justify-content: center; }
+.export-preview-panel { background: #fff; border-radius: 8px; width: min(860px, 90vw); max-height: 80vh; display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25); }
+.export-preview-head { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; border-bottom: 1px solid rgba(90, 45, 133, 0.15); }
+.export-preview-head strong { font-size: 13px; color: rgba(90, 45, 133, 0.95); }
+.export-preview-loading, .export-preview-error { padding: 18px; font-size: 12px; color: rgba(65, 65, 65, 0.75); }
+.export-preview-error { color: #c0392b; }
+.export-preview-desc { padding: 10px 14px; background: rgba(90, 45, 133, 0.04); border-bottom: 1px solid rgba(90, 45, 133, 0.1); font-size: 11px; color: rgba(65, 65, 65, 0.8); display: grid; gap: 3px; }
+.export-preview-desc p { margin: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.export-preview-table { width: 100%; border-collapse: collapse; font-size: 11px; }
+.export-preview-table th, .export-preview-table td { border: 1px solid rgba(90, 45, 133, 0.12); padding: 4px 6px; text-align: left; max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.export-preview-table th { background: rgba(90, 45, 133, 0.08); position: sticky; top: 0; }
+.export-preview-panel > div:last-child { overflow: auto; }
 @media (max-width: 1050px) {
     .obtainer-status-panel { width: 860px; grid-template-columns: 0.9fr 1.25fr 0.9fr; }
     .status-column { padding-left: 10px; padding-right: 10px; }

--- a/ui/src/components/manage/obtainerLake/datasetManager.vue
+++ b/ui/src/components/manage/obtainerLake/datasetManager.vue
@@ -105,6 +105,9 @@
             <span>已导出：</span>
             <code @click="copyText(exportNotice)">{{ exportNotice }}</code>
             <span class="dm-copy-hint">（点击复制）</span>
+            <button type="button" class="dm-btn" @click="downloadExport" :disabled="downloading">
+                {{ downloading ? '下载中…' : '下载到浏览器' }}
+            </button>
         </section>
 
         <!-- Detail drawer -->
@@ -309,6 +312,7 @@ export default {
             saving: false,
             busy: false,
             exportNotice: '',
+            downloading: false,
             showIngest: false,
             ingesting: false,
             ingestError: '',
@@ -461,6 +465,16 @@ export default {
                 this.error = err?.message || '导出失败'
             } finally {
                 this.busy = false
+            }
+        },
+        async downloadExport() {
+            const uri = this.exportNotice
+            if (!uri) return
+            this.downloading = true
+            try {
+                window.open(`/api/obtainer/export/download?uri=${encodeURIComponent(uri)}`, '_blank')
+            } finally {
+                this.downloading = false
             }
         },
         async clearSamples(ds) {

--- a/ui/src/router/Manage/index.js
+++ b/ui/src/router/Manage/index.js
@@ -23,6 +23,10 @@ export default {
             component: AsyncLoad(() => import("@/views/manage/obtainerLake/index.vue"))
         },
         {
+            path: 'datamixer/datasets',
+            component: AsyncLoad(() => import("@/views/manage/obtainerLake/index.vue"))
+        },
+        {
             path: 'obtainer-lake',
             redirect: '/m/datamixer'
         }


### PR DESCRIPTION
## 概述
obtainer 数据获取链路的两项策略增强 + 配套的出湖/导出 UI 与基础设施。

## 主要改动

### 1. Benchmark 注册守卫（防数据泄露）
- 用户 query / Analyzer report 明确点名 benchmark 类型时（如 HumanEval-style、BIRD），先注册到 DataMixer benchmark 注册层（`dm contam add`）再入湖
- 注册后 ingest/export 的去污染（decontamination）自动排除这些样本，防止 benchmark 泄露进训练数据
- 同步进 obtainer skill（`skills/obtainer/SKILL.md`）与 `dataset-acquisition-agent` worker 策略（rule 13），真实 agent 已实测：注册 + 入湖时自动拦截生效

### 2. 出湖质量门：默认 L4，用户指定时可 L3 直接出湖
- 之前规定"只有 L4 才能出湖"；现改为：默认仍走 DataFlow L4 门，但用户明确指定 L3 出湖时豁免 L4 门，L3 数据可直接出湖（湖内 volume/mix/quality 门仍生效）
- 同步更新：SKILL.md、orchestrator 策略、dataflow agent 策略、`docs/OBTAINERCLI_USAGE.md`
- 已验证：`recipe export` 可直接导出 L3 数据（机制本身不拦 L3，原先是策略层限制）

### 3. 配套（工作区原有未提交改动，一并提交）
- api：obtainer 出湖文件下载/预览端点、manifest 描述富化
- monitor：导出预览富化
- codex-runner + datamixer codex adapter：prompt 改为文件投递（避免 ARGV 上限）、运行后清理
- dataflow_agent：LLM `<answer>` 标签解析健壮性
- ui：obtainer 状态面板 / dataset manager 更新、路由清理
- docs：MinerU-HTML 部署教程

## 测试
- 真实 Codex agent（deepseek-v4-flash）验证 benchmark 注册 + 入湖自动拦截：`contaminated=1, written=1, contam_sources={humaneval_style:1}`，湖内无 benchmark 原文
- CLI 验证 L3 直接出湖：`ingest --quality-level L3` → `recipe export` 成功导出
